### PR TITLE
docs: use website URL for contact, not email

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ any Claude Code session.
 > The skill's actual instructions live in [`SKILL.md`](SKILL.md); the deep, per-topic
 > standards live in [`references/`](references/).
 
-- **Author:** Brian Greenberg · **Contact:** brian@briangreenberg.net
+- **Author:** Brian Greenberg · **Web:** https://briangreenberg.net
 - **Version:** see the metadata table at the bottom of [`SKILL.md`](SKILL.md) (currently v1.0.0)
 - **Invoke:** `/senior-engineering-partner` in Claude Code, optionally prefixed with a
   mode trigger word (see [Modes](#modes--triggers)).

--- a/SKILL.md
+++ b/SKILL.md
@@ -349,7 +349,7 @@ The moment a second writer — agent or human — is in the tree, the solo-speed
 | Field | Value |
 |---|---|
 | **Author** | Brian Greenberg |
-| **Contact** | brian@briangreenberg.net |
+| **Website** | https://briangreenberg.net |
 | **License** | Apache-2.0 |
 | **Created** | 2026-05-18 |
 | **Last updated** | 2026-06-25 |

--- a/scripts/leakage-guard.sh
+++ b/scripts/leakage-guard.sh
@@ -29,6 +29,7 @@ denylist+='|my\.1password'
 denylist+='|\bchezmoi\b|fleet-pkg|dot_Brewfile'
 denylist+='|both Macs|two Macs|two-Mac'
 denylist+='|forensic|phishing|chain.of.custody|invoice fraud'   # product-domain fingerprints
+denylist+='|brian@'   # personal email — attribution uses the website URL, not an address
 denylist+='|\[\[[A-Za-z]'   # [[wikilink]] — NOT a Bash [[ test (which has a space after [[)
 
 # Files to scan: tracked Markdown/JSON/shell, excluding this script and the private profile.
@@ -39,7 +40,7 @@ mapfile -t files < <(
 )
 
 # Allowlist: lines that legitimately contain a denylisted-looking token (author attribution).
-allow='Brian Greenberg|brian@briangreenberg\.net'
+allow='Brian Greenberg|briangreenberg\.net'
 
 hits=0
 for f in "${files[@]}"; do


### PR DESCRIPTION
Replaces the personal email (README + SKILL.md metadata) with https://briangreenberg.net. Hardens `leakage-guard.sh` to deny a personal email going forward (self-tested: the guard now fails if an email is reintroduced).

Docs-only; both CI gates apply.