### PR TITLE
docs: add community-health files for public release

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,18 @@
+# CODEOWNERS — documents who owns each part of the skill, and (when branch protection's
+# "require review from Code Owners" is enabled) routes review on the parts where a bad change
+# does the most harm. Every path must resolve to a user with repo access, or GitHub silently
+# skips the owner — so keep these current.
+
+# Default owner for everything
+*                       @bjgreenberg
+
+# The skill's contract and its disciplines — the heart of the project
+/SKILL.md               @bjgreenberg
+/references/            @bjgreenberg
+
+# Tooling that gates the repo (the leakage / render / audit checks themselves)
+/scripts/               @bjgreenberg
+/.github/               @bjgreenberg
+
+# The regression suite that guards the disciplines
+/evals/                 @bjgreenberg

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,53 @@
+name: Bug report
+description: Something in the skill is wrong, broken, or unclear.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping improve the skill.
+
+        **For questions, ideas, or general feedback, please use
+        [Discussions](https://github.com/bjgreenberg/senior-engineering-partner/discussions)
+        instead** — Issues are for actionable bugs. For anything security-related, see
+        [SECURITY.md](https://github.com/bjgreenberg/senior-engineering-partner/blob/main/SECURITY.md)
+        (don't file it here).
+  - type: textarea
+    id: what
+    attributes:
+      label: What's wrong?
+      description: What does the skill do, say, or recommend that's incorrect, broken, or confusing?
+    validations:
+      required: true
+  - type: input
+    id: where
+    attributes:
+      label: Where in the skill?
+      description: Which file or section (e.g. `SKILL.md`, `references/databases.md`, a specific rule)?
+    validations:
+      required: false
+  - type: textarea
+    id: repro
+    attributes:
+      label: How to reproduce
+      description: The prompt or task you gave, and what the assistant produced.
+      placeholder: |
+        1. Invoked the skill with: …
+        2. Asked it to: …
+        3. It responded: …
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected vs. actual
+      description: What should have happened, and what actually happened?
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: Claude Code version, OS, model (e.g. Opus 4.x), and how you invoked the skill.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Questions, ideas & feedback
+    url: https://github.com/bjgreenberg/senior-engineering-partner/discussions
+    about: Ask a question, suggest an idea, or share feedback in Discussions — this keeps Issues focused on actionable bugs.
+  - name: Report a security issue (privately)
+    url: https://github.com/bjgreenberg/senior-engineering-partner/security/advisories/new
+    about: Report a vulnerability privately. Please do not open a public issue. See SECURITY.md.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,26 @@
+<!--
+Conventional-Commit PR title (it becomes the squash-merge history entry), e.g.
+  feat: add a circuit-breaker pattern to resilience-engineering.md
+  fix: correct the squash-merge wording in the SCM section
+  docs: clarify the my-environment.md fork step
+-->
+
+## What changed
+
+
+## Why it changed
+
+
+## Testing
+<!-- How you verified it: gates run, render-checks, what you read/tested. -->
+
+
+---
+<!-- Contributor checklist — see CONTRIBUTING.md. Tick what applies. -->
+- [ ] Branch is rebased on the latest `main`; PR title is a Conventional Commit.
+- [ ] Small and single-purpose (one change per PR).
+- [ ] Docs updated in **this** PR — README / the relevant `references/*.md` / any diagram or step-list the change touches; and if a discipline changed, the `SKILL.md` changelog entry + `Version` bump (this repo's changelog lives in `SKILL.md`, not a separate `CHANGELOG.md`).
+- [ ] `bash scripts/leakage-guard.sh` and `bash scripts/render-diagrams.sh` pass locally (and any Mermaid I touched renders).
+- [ ] No host/employer/personal identifiers added to the universal core (those live in a private `references/my-environment.md`).
+- [ ] If I added or changed a discipline, an `evals/` scenario guards it.
+- [ ] I self-reviewed the diff (correctness, scope, security).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement via
+<https://briangreenberg.net>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,94 @@
+# Contributing
+
+Thanks for helping improve **senior-engineering-partner**. This skill is maintained the way it
+teaches: contributions follow the same disciplines the skill itself prescribes (see
+[`SKILL.md`](SKILL.md) — *Source Code Management*, the engineering workflow, and
+`references/multi-agent-coordination.md` / `references/github-teams.md`). Those rules aren't
+bureaucracy here; they're the product. This guide distils them for contributors.
+
+It's deliberately scaled for a small project — one maintainer plus the occasional contributor.
+None of it is heavy.
+
+**Sending a one-line fix?** Just open the PR. The eval, changelog, and version-bump steps below
+only apply when you change a *discipline* or behavior — not for a typo or a small doc tweak.
+
+## Where things go
+
+| You have… | Put it in… |
+|---|---|
+| A **bug** — something in the skill is wrong, broken, or unclear | an **Issue** (use the bug-report form) |
+| A **question, idea, or feedback** | **[Discussions](https://github.com/bjgreenberg/senior-engineering-partner/discussions)** (Q&A / Ideas) |
+| A **security** concern or a way the skill could be misused | **privately** — see [`SECURITY.md`](SECURITY.md) (never a public issue) |
+
+Keeping bugs in Issues and everything open-ended in Discussions is what keeps both useful.
+
+## The contribution workflow
+
+This is GitHub Flow with the skill's guardrails. Outside contributors work from a **fork**;
+regular collaborators use a branch on the repo. Either way:
+
+1. **One short-lived branch per change** — `feat/…`, `fix/…`, `docs/…`. Never work on `main`;
+   `main` is the integration point, not a scratchpad.
+2. **Sync before you push:** `git fetch && git rebase origin/main`, so you integrate the latest
+   work and resolve any conflict in *your* tree. We keep **linear history**. If a conflict is in
+   content you don't own or understand, **stop and ask** in the PR rather than guessing — a wrong
+   resolution silently drops someone's change.
+3. **Stage by explicit path** (`git add path/to/file`) — never `git add -A` / `git add .`. Your
+   commit contains only the files your change touches.
+4. **Conventional Commits.** Your **PR title** is a Conventional Commit (`feat:`, `fix:`, `docs:`,
+   `chore:`, `test:`, `refactor:`). Because we **squash-merge**, the PR title *becomes the
+   permanent history entry* — write it like one.
+5. **Update the docs in the same PR.** If you change behavior, update *every* representation of it
+   — the README, the relevant `references/*.md`, and any diagram or numbered step-list the change
+   touches (a stale diagram is a *wrong* diagram). If you change a **discipline**, also bump the
+   **`Version`** field and add the matching **`#### vX.Y` entry** under the `### Changelog` heading
+   in `SKILL.md`'s metadata table — that embedded section *is* this skill's changelog (there is no
+   separate `CHANGELOG.md`). This is the skill's own same-commit-docs rule, applied to itself.
+6. **Keep the universal core stack-agnostic.** `SKILL.md` and the references must not contain
+   host, employer, or personal identifiers — those belong in a contributor's own
+   `references/my-environment.md` (which is gitignored and never committed). The **`leakage-guard`**
+   check enforces this; don't add anything that trips it.
+7. **If you encode a discipline, guard it with an eval.** New or changed rules should add or extend
+   a scenario in `evals/` — the project's "changelog is the spec, evals are the tests" model.
+8. **Run the gates locally** before opening the PR: `bash scripts/leakage-guard.sh` and
+   `bash scripts/render-diagrams.sh` (render-check any Mermaid you touched). Locally-green is
+   necessary but **not sufficient** — the PR's required checks are the source of truth.
+9. **Open the PR** with the **What changed / Why it changed / Testing** description (the PR template
+   gives you the shape). Open it as a **draft** while it's WIP so CI runs but it can't merge early;
+   mark it ready when it is. Link the issue it closes (`Closes #N`).
+10. **"Done" means merged via a green PR** — not pushed to a branch.
+
+Keep PRs **small and single-purpose** — one change per PR. A reviewer can hold the whole diff in
+their head, and CI catches problems early.
+
+## How your PR gets reviewed and merged
+
+- **A maintainer reviews every contributor PR before it merges** — read like a code review, with
+  every review thread addressed or resolved. We don't merge on green CI alone: green proves the
+  *gates* passed, not that the change is correct, in-scope, and free of a subtle regression a check
+  didn't cover.
+- The repo's **required checks** (`docs-render`, `leakage-guard`) must pass.
+- Merges are **squash-only** — rebase-merge (it rewrites your commits *unsigned*) and merge-commit
+  are both disabled — and the branch is auto-deleted on merge. GitHub signs the squash commit, so
+  your contribution lands **Verified** on `main` even if your own commits weren't signed; you don't
+  need to set up signing.
+
+> **A note on the "0 required reviews" setting.** The branch ruleset doesn't *mechanically* require
+> an approval. That's a deliberate accommodation so the solo maintainer can merge their own work
+> (where a documented self-review stands in for a second reviewer). It is **not** a waiver:
+> **contributor PRs are reviewed by a maintainer as a matter of policy** before they land. This
+> mirrors the skill's own rule — *your own hand-written change, green checks suffice; someone
+> else's change, a human reviews it* (`references/github-teams.md` §3).
+
+[`CODEOWNERS`](.github/CODEOWNERS) documents who owns which parts of the skill; if required reviews
+are ever turned on, it routes review automatically on the sensitive paths.
+
+## Code of Conduct
+
+By participating you agree to the [Code of Conduct](CODE_OF_CONDUCT.md).
+
+## Licensing
+
+By submitting a contribution, you agree it is licensed under this project's
+[Apache-2.0](LICENSE) license (inbound = outbound). That's all — there's no separate CLA or DCO
+sign-off to remember.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+`senior-engineering-partner` is a Claude Code **skill** — Markdown instructions plus a few helper
+shell scripts. It ships no running service and holds no secrets, so the security surface is narrow,
+but it's real:
+
+- **Helper scripts** under `scripts/` — e.g. an injection or unsafe-handling bug in a shell helper.
+- **Skill content that could be abused** — e.g. an instruction-injection vector, or guidance that,
+  if followed, would weaken a user's security posture.
+- **Reintroduced identifiers** — the skill is deliberately scrubbed of environment-specific detail;
+  a regression that puts personal, host, or employer data back into the public tree is a privacy
+  issue (`scripts/leakage-guard.sh` guards against it).
+
+## Reporting a vulnerability
+
+**Please don't open a public issue for a security report.**
+
+- **Preferred:** use GitHub's **private vulnerability reporting** — the **Security → "Report a
+  vulnerability"** button on this repository. It opens a private advisory only the maintainer can
+  see.
+- **Alternatively:** contact the maintainer via **<https://briangreenberg.net>**.
+
+Please include what you found, how to reproduce it, and the impact. You'll get an acknowledgement
+within a few days, and a fix worked under coordinated disclosure — with credit to you unless you'd
+prefer to stay anonymous.
+
+## Supported versions
+
+This is a rolling, single-branch project: fixes land on `main`. Please report against the current
+`main`.


### PR DESCRIPTION
## What changed
Adds the contributor-governance files for the public release:
- `CONTRIBUTING.md`, `SECURITY.md`, `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1)
- `.github/ISSUE_TEMPLATE/bug_report.yml` + `config.yml` (structured bug form; blank issues off; questions/ideas → Discussions; security → private advisory)
- `.github/pull_request_template.md` (What/Why/Testing + contributor checklist)
- `.github/CODEOWNERS` (documents ownership of the sensitive paths)

## Why it changed
The skill teaches team-contribution discipline; the repo should follow it. `CONTRIBUTING.md` distils the skill's own rules (`references/multi-agent-coordination.md`, `references/github-teams.md`, SKILL.md SCM) so a friend/community PR follows the same fork → branch → rebase → explicit-path → squash flow, with the What/Why/Testing description and same-commit docs.

## Testing
- `bash scripts/leakage-guard.sh` → PASS (no environment-specific identifiers; contact is the website, no email)
- Issue-form + `config.yml` validated as YAML (ruby) and against GitHub's issue-form schema (valid `markdown`/`input`/`textarea` types)
- Adversarial 3-lens review (rule-fidelity / technical-correctness / tone-and-scale) → "high-fidelity", schemas/links/CODEOWNERS valid; fixes applied (CHANGELOG→SKILL.md-changelog wording, rebase-vs-merge signature precision, a one-line-fix carve-out)
- No Mermaid added → `docs-render` unaffected

## Notes for your review (maintainer)
- **0 required reviews kept** as you asked. `CONTRIBUTING.md` frames it honestly: the ruleset doesn't *mechanically* require an approval (so you can self-merge your own work), but contributor PRs get a maintainer review **as policy** — exactly `github-teams.md` §3.
- **No `SKILL.md` Version bump** — these are governance files, not a change to the skill's disciplines. Say the word if you'd rather treat it as a `v1.0.1`.
- Minor wording inconsistency you may want to align later: the README says "every deliberate change" bumps the Version, while `CONTRIBUTING.md` scopes the bump to *discipline/behavior* changes (the more practical reading). Not changed here.
