### PR TITLE
docs: add an as-is / no-warranty disclaimer to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # senior-engineering-partner
 
-Last updated: 2026-06-25 10:35 PM CDT
+Last updated: 2026-06-26 11:57 AM CDT
 
 A custom Claude Code skill: a strict **code reviewer, pair programmer, debugger, and mentor** for
 Python, Bash, Google Apps Script, and JavaScript. It encodes a security-first,
@@ -234,3 +234,11 @@ environment-specific claim**, so the more complete it is, the more grounded the 
 ## License
 
 Apache-2.0 © Brian Greenberg. See [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE).
+
+## Disclaimer
+
+This skill is provided **as is**, without warranty of any kind, under the Apache-2.0 license —
+see the *Disclaimer of Warranty* (§7) and *Limitation of Liability* (§8) sections of
+[`LICENSE`](LICENSE). It offers **engineering guidance, not professional security, legal, or
+compliance advice**. Review and validate any code, configuration, or security decision it
+influences before relying on it — you are responsible for what you ship.


### PR DESCRIPTION
## What changed
Adds a **Disclaimer** section to the README + bumps the Last-updated stamp.

## Why it changed
The Apache-2.0 `LICENSE` already carries the legal waiver (§7 Disclaimer of Warranty, §8 Limitation of Liability), but the README restated none of it. Since this skill dispenses engineering **and security** guidance, the README now states plainly: provided as-is, no warranty; engineering guidance, not professional security/legal/compliance advice; review and validate anything it influences.

## Testing
- `leakage-guard` clean (no identifiers); no Mermaid touched (`docs-render` unaffected).
- Docs-only, additive.