### PR TITLE
ci: add Dependabot github-actions updates + SHA-pin actions/checkout

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  # Keep the GitHub Actions used by CI current and SHA-fresh.
+  # github-actions is the only ecosystem here (the repo is Markdown + Shell;
+  # no pip/npm/docker manifests). Dependabot bumps the pinned SHAs with a changelog.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"

--- a/.github/workflows/docs-render.yml
+++ b/.github/workflows/docs-render.yml
@@ -16,7 +16,7 @@ jobs:
   docs-render:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Render every Mermaid diagram
         run: |
           set -euo pipefail

--- a/.github/workflows/leakage-guard.yml
+++ b/.github/workflows/leakage-guard.yml
@@ -17,6 +17,6 @@ jobs:
   leakage-guard:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Scan for environment-specific identifiers
         run: bash scripts/leakage-guard.sh


### PR DESCRIPTION
## What changed
- Adds `.github/dependabot.yml` (github-actions ecosystem, weekly) — the only ecosystem in the repo.
- SHA-pins `actions/checkout` from the `@v4` tag to commit `34e1148` (`# v4.3.1`) in both `docs-render` and `leakage-guard` workflows.

## Why it changed
The security audit's one **important** gap: the skill mandates a `dependabot.yml` covering every ecosystem, but the repo had none — so `actions/checkout` got no routine version-bump PRs and the pinned ref drifted untended. SHA-pinning makes the action integrity-checked (not a movable tag), and Dependabot now keeps the SHA current with a changelog. Also satisfies the newly-enabled code-scanning *actions* analyzer.

## Testing
- `leakage-guard` clean; no Mermaid touched (`docs-render` unaffected). The workflows still `checkout` at a valid ref (the v4.3.1 commit).