### PR TITLE
fix: two-tier leakage-guard (keep literals private) + trim frontmatter description ≤1024

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # The private environment profile — created from my-environment.template.md, never committed.
 references/my-environment.md
 
+# The private per-user literal denylist — created from leakage-denylist.local.template, never committed.
+references/leakage-denylist.local
+
 # macOS / editor / Python junk
 .DS_Store
 __pycache__/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,11 @@ regular collaborators use a branch on the repo. Either way:
 6. **Keep the universal core stack-agnostic.** `SKILL.md` and the references must not contain
    host, employer, or personal identifiers — those belong in a contributor's own
    `references/my-environment.md` (which is gitignored and never committed). The **`leakage-guard`**
-   check enforces this; don't add anything that trips it.
+   check enforces this; don't add anything that trips it. Your own *literal* identifiers go in an
+   un-committed `references/leakage-denylist.local` (copy it from the `.template`) — that file guards
+   the tree locally without ever being published. When a co-maintainer joins, add their **public**
+   handle to CODEOWNERS/attribution (don't denylist it), but add **their** personal hosts / private-repo
+   names / email to their own local denylist.
 7. **If you encode a discipline, guard it with an eval.** New or changed rules should add or extend
    a scenario in `evals/` — the project's "changelog is the spec, evals are the tests" model.
 8. **Run the gates locally** before opening the PR: `bash scripts/leakage-guard.sh` and

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # senior-engineering-partner
 
-Last updated: 2026-06-26 11:57 AM CDT
+Last updated: 2026-06-28 11:13 PM CDT
 
 A custom Claude Code skill: a strict **code reviewer, pair programmer, debugger, and mentor** for
 Python, Bash, Google Apps Script, and JavaScript. It encodes a security-first,
@@ -14,7 +14,7 @@ any Claude Code session.
 > standards live in [`references/`](references/).
 
 - **Author:** Brian Greenberg · **Web:** https://briangreenberg.net
-- **Version:** see the metadata table at the bottom of [`SKILL.md`](SKILL.md) (currently v1.0.0)
+- **Version:** see the metadata table at the bottom of [`SKILL.md`](SKILL.md) (currently v1.1.0)
 - **Invoke:** `/senior-engineering-partner` in Claude Code, optionally prefixed with a
   mode trigger word (see [Modes](#modes--triggers)).
 
@@ -225,9 +225,12 @@ environment-specific claim**, so the more complete it is, the more grounded the 
   `@mermaid-js/mermaid-cli` (`mmdc`) — see
   [`references/diagrams-and-visual-docs.md`](references/diagrams-and-visual-docs.md). CI
   runs `scripts/render-diagrams.sh` (the `docs-render` gate) on every PR.
-- **No environment-specific leakage in the core:** CI also runs a `leakage-guard` check that
-  greps the tree against a denylist of personal/host/repo identifiers — keep the universal
-  core universal; anything specific belongs in your (un-committed) `my-environment.md`.
+- **No environment-specific leakage in the core:** a `leakage-guard` check greps the tree against
+  a denylist of personal/host/repo identifiers. It's **two-tier**: generic class-patterns (a
+  CGNAT/Tailscale IP range, Obsidian-style wiki-links) ship in `scripts/leakage-guard.sh` and run in CI,
+  while your *literal* identifiers live in an un-committed `references/leakage-denylist.local`
+  (created from its `.template`) so the public repo never has to publish them to block them. Keep
+  the universal core universal; anything specific belongs in your (un-committed) `my-environment.md`.
 - **Add or extend an `evals/` scenario** whenever you add a load-bearing rule — a lesson
   without a guarding eval can silently regress.
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: senior-engineering-partner
-description: A strict code reviewer, pair programmer, debugger, and mentor for Python, Bash, Google Apps Script, and JavaScript. Use when writing, reviewing, debugging, planning, or securing code, or when the user wants senior-level rigor, a security review, or mentoring. Mode triggers — REVIEW: (critique + refactor), EXPLAIN: (teach), MVP:/PROTOTYPE: (lean-but-safe), DEBUG: (root-cause). Drives a spec→plan→TDD→self-review workflow with a deterministic-first, verify-before-asserting (anti-hallucination) discipline. Enforces a security floor (1Password secrets, injection/input-validation, isolation, least privilege) on a phase-aware rigor ladder (Prototype→MVP→Production). Enforces a backup & continuity floor (every data-holding system has a restore-verified backup; degrade-don't-die in the code) on the same rigor ladder. Covers testing (+ fuzzing/DAST) + SAST/secret-scan + type-check (mypy/pyright/ruff) + supply-chain-integrity gates (pin/hash-lock inputs; SBOM + SLSA provenance on outputs), TypedDicts, FOSS vetting, multi-tenant data protection, scalability & system design (stateless/queues/DLQ/outbox), resilience engineering (circuit breaker/bulkhead/timeouts/degraded modes), disaster recovery (3-2-1-1-0 immutable backups, restore drills) + business continuity (BIA, provider-outage, bus-factor), DORA delivery metrics, and per-toolchain standards — Docker/Kubernetes, GCP/Cloud Run, databases (Postgres/Supabase/BigQuery/SQLite, RLS), FastAPI, GitHub Actions, NIST CSF + SSDF/OWASP/SOC 2/Well-Architected, macOS app-bundle/TCC, accessible (WCAG 2.2 AA) UI, and diagrams + docs.
+description: A strict code reviewer, pair programmer, debugger, and mentor for Python, Bash, Google Apps Script, and JavaScript. Use when writing, reviewing, debugging, planning, or securing code, or for senior-level rigor, a security review, or mentoring. Mode triggers — REVIEW: (critique + refactor), EXPLAIN: (teach), MVP:/PROTOTYPE: (lean-but-safe), DEBUG: (root-cause); default is pair-programming. Drives a spec→plan→TDD→verify loop with a deterministic-first, verify-before-asserting (anti-hallucination) discipline. Enforces a security floor (secrets in a manager, injection & input validation, isolation, least privilege, authn) and a backup/continuity floor on a phase-aware rigor ladder (Prototype→MVP→Production) — cheap ≠ insecure. Covers testing & fuzzing, SAST + secret-scan + type-check + supply-chain gates (SBOM/SLSA), multi-tenant data protection, resilience & DR, scalability, CI/CD, cloud/containers/DBs, and accessible UI — deep per-toolchain references read on demand.
 ---
 # ROLE AND CONTEXT
 You are an elite Software Engineering Partner and Senior Developer with deep experience across the whole arc — from a cheap throwaway prototype, through an MVP shipped to real users, to a production-grade commercial multi-tenant application — covering internal tooling, automation pipelines, administrative systems, web/GUI front-ends, and data services. Your primary goal is to do the heavy lifting: design, write, test, and maintain code. Calibrate explanations and depth to an intermediate Python and Bash developer.
@@ -352,8 +352,8 @@ The moment a second writer — agent or human — is in the tree, the solo-speed
 | **Website** | https://briangreenberg.net |
 | **License** | Apache-2.0 |
 | **Created** | 2026-05-18 |
-| **Last updated** | 2026-06-25 |
-| **Version** | 1.0.0 |
+| **Last updated** | 2026-06-28 |
+| **Version** | 1.1.0 |
 
 ### Changelog
 
@@ -362,6 +362,18 @@ revisions before its public release. The history below is the **public** changel
 internal-version specifics (private project names, hosts, and work history) are intentionally
 omitted, and the universal core carries **zero** environment-specific detail — all of that lives
 in your own `references/my-environment.md`.
+
+#### v1.1.0 — 2026-06-28 — Evaluation follow-ups
+Fixes from a full skill self-evaluation. Privacy & authoring correctness first:
+- **Two-tier `leakage-guard`.** Generic class-patterns (a CGNAT/Tailscale IP range, Obsidian-style
+  wiki-links) stay in the public `scripts/leakage-guard.sh` and run in CI; your *literal* identifiers now live in
+  an un-committed `references/leakage-denylist.local` (from a new `.template`), so the public repo no
+  longer has to publish hostnames/employer/repo names in order to block them.
+- **Frontmatter `description` trimmed to ≤1024 chars** (was ~1.6k, over Anthropic's hard limit) — kept
+  the role, languages, `Use when`, and the mode triggers; moved the framework enumeration to the body.
+- **Fixed the `render-diagrams.sh` digest comment** (it claimed to ship no digest while pinning one; the
+  pinned digest is published — the comment was wrong, not the pin).
+- Noted that eval `source` version tokens (`v2.x–v6.x`) are pre-release provenance, not public versions.
 
 #### v1.0.0 — 2026-06-25 — Initial public release
 - First public, sanitized release: a **stack-agnostic universal core** (`SKILL.md`, always

--- a/evals/README.md
+++ b/evals/README.md
@@ -36,6 +36,10 @@ the matching scenario catches it instead of a production incident re-teaching th
 `expected_behavior`); they make the "never do this again" framing explicit and trace each scenario to its
 origin.
 
+> **Note on the `source` version tokens.** Some `source` fields cite internal pre-release revisions
+> (e.g. `v4.0`, `v5.4`) that predate the public `v1.0.0` release and intentionally do **not** appear in
+> the SKILL.md changelog — treat them as provenance notes, not resolvable versions.
+
 ## How to run (no built-in runner exists)
 
 There is no first-party eval runner today, so run them as a structured manual/LLM-judge loop:

--- a/references/leakage-denylist.local.template
+++ b/references/leakage-denylist.local.template
@@ -1,0 +1,40 @@
+# leakage-denylist.local.template — copy to references/leakage-denylist.local (which is
+# .gitignore'd) and replace the examples with YOUR private identifiers.
+#
+#   cp references/leakage-denylist.local.template references/leakage-denylist.local
+#
+# scripts/leakage-guard.sh sources the .local file (if present) and ORs each line into its
+# denylist as a POSIX extended-regex (ERE) fragment, case-insensitively. This is Tier 2 of the
+# guard: your LITERAL fingerprints (hostnames, employer, repo/project names, private IPs) stay in
+# this UN-COMMITTED file, so the public repo never has to publish them in order to catch a leak.
+# (The committed guard ships only generic Tier-1 patterns — a CGNAT IP range and [[wikilinks]] —
+# that name nothing personal. CI runs Tier 1 only; your local pre-PR run runs Tier 1 + Tier 2.)
+#
+# Format: one ERE fragment per line; lines starting with '#' are comments; blank lines are ignored.
+# Escape regex metacharacters (a literal dot is \. ). Use \b...\b word boundaries for short tokens
+# that would otherwise match inside ordinary words.
+#
+# Replace everything below with your own, then delete these examples:
+
+# Hosts / machines
+# my-laptop-hostname
+# my-server-hostname
+
+# Employer / org
+# \bAcmeCorp\b
+# acmecorp-github-org
+
+# Private repos / projects / cloud projects
+# my-private-app
+# myproject-(dev|staging|prod|tfstate)
+
+# Vendor / SaaS stack (whatever would fingerprint you or your employer)
+# \bVendorA\b
+# \bVendorB\b
+
+# Private / VPN IPs (escape the dots)
+# 10\.0\.0\.5
+# 192\.168\.1\.50
+
+# Personal email prefix (attribution should use your website/handle, not an address)
+# me@

--- a/scripts/leakage-guard.sh
+++ b/scripts/leakage-guard.sh
@@ -4,12 +4,23 @@
 # public skill. The universal core must stay universal; anything specific belongs in your
 # (un-committed) references/my-environment.md.
 #
-# Run locally before a PR and as a required CI check. Exits non-zero (printing every hit) if
-# a denylisted identifier appears anywhere in the tracked tree.
+# TWO-TIER denylist, so the PUBLIC repo never has to publish your personal identifiers in
+# order to block them:
+#   Tier 1 — GENERIC class-patterns below (a CGNAT/Tailscale IP range, [[wikilinks]]). These
+#            name nothing personal, so they ship in this public file and run in CI.
+#   Tier 2 — your LITERAL identifiers (hostnames, employer, repo/project names, private IPs)
+#            live in references/leakage-denylist.local — an UN-COMMITTED file created from
+#            leakage-denylist.local.template and sourced here if present. So your fingerprints
+#            guard the tree LOCALLY without ever being written into the public repo or its
+#            history. (CI, which has no .local file, enforces only the generic Tier-1 patterns;
+#            the local pre-PR run is the primary gate — see CONTRIBUTING.md.)
 #
-# Allowed by design: author attribution ("Brian Greenberg" / the contact email) in README.md
-# and SKILL.md's metadata table — these are intentional and matched out below. The private
-# references/my-environment.md is .gitignore'd and never scanned.
+# Run locally before a PR (Tier 1 + Tier 2) and as a CI check (Tier 1 only). Exits non-zero
+# (printing every hit) if a denylisted identifier appears anywhere in the tracked tree.
+#
+# Allowed by design: author attribution ("Brian Greenberg" / the website URL) in README.md and
+# SKILL.md's metadata table — matched out below. references/my-environment.md and
+# references/leakage-denylist.local are never scanned (the latter has a non-scanned extension).
 #
 # Usage:  scripts/leakage-guard.sh
 set -euo pipefail
@@ -17,20 +28,22 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
-# Denylist of identifiers that must NEVER appear in the public skill (ERE, case-insensitive).
-# Grouped: hosts · employer · vendor stack · products/repos · cloud projects · secret-mgr
-# account · machine-fleet tooling · multi-machine phrasing · Obsidian-style [[wikilinks]].
-denylist='socrates|Brians-MBP|brians-macbook|aristotle'
-denylist+='|\bRHR\b|rhrinternational'
-denylist+='|\bOkta\b|\bJamf\b|\bIntune\b|HubSpot|NetSuite|Celigo|Seismic|KnowBe4|Alteryx|Monday\.com|Looker'
-denylist+='|forensics-analyzer|forensics-matters|vendor-logos|vendor-dashboard|\bnetqlty\b|mdmtools|journal-ai|vault-readme|mac-power-monitor|bjg-brand|developer-handbook|deepfake'
-denylist+='|forensics-dev|forensics-prod|forensics-tfstate'
-denylist+='|my\.1password'
-denylist+='|\bchezmoi\b|fleet-pkg|dot_Brewfile'
-denylist+='|both Macs|two Macs|two-Mac'
-denylist+='|forensic|phishing|chain.of.custody|invoice fraud'   # product-domain fingerprints
-denylist+='|brian@'   # personal email — attribution uses the website URL, not an address
+# --- Tier 1: GENERIC class-patterns (safe to ship; reveal nothing personal). ERE, case-insensitive.
+denylist='100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.[0-9]{1,3}\.[0-9]{1,3}'  # CGNAT/Tailscale 100.64.0.0/10
 denylist+='|\[\[[A-Za-z]'   # [[wikilink]] — NOT a Bash [[ test (which has a space after [[)
+
+# --- Tier 2: your private LITERAL identifiers, sourced from an un-committed file (if present).
+#     One POSIX-ERE fragment per line; '#' lines and blanks are ignored.
+local_list="references/leakage-denylist.local"
+if [[ -f "$local_list" ]]; then
+  while IFS= read -r frag; do
+    frag="${frag%$'\r'}"                                 # strip a trailing CR
+    [[ "$frag" =~ ^[[:space:]]*(#.*)?$ ]] && continue    # skip blank / comment lines
+    frag="${frag#"${frag%%[![:space:]]*}"}"              # ltrim
+    frag="${frag%"${frag##*[![:space:]]}"}"              # rtrim
+    denylist+="|${frag}"
+  done < "$local_list"
+fi
 
 # Files to scan: tracked Markdown/JSON/shell, excluding this script and the private profile.
 mapfile -t files < <(
@@ -57,7 +70,8 @@ for f in "${files[@]}"; do
 done
 
 if [[ "$hits" -ne 0 ]]; then
-  echo "FAIL: ${hits} leak(s). Move environment-specific detail into references/my-environment.md (un-committed)." >&2
+  echo "FAIL: ${hits} leak(s). Move environment-specific detail into references/my-environment.md (un-committed)" >&2
+  echo "      or add the identifier to references/leakage-denylist.local — never into a tracked file." >&2
   exit 1
 fi
 echo "PASS: no environment-specific identifiers in the public skill."

--- a/scripts/render-diagrams.sh
+++ b/scripts/render-diagrams.sh
@@ -12,10 +12,10 @@
 #          scripts/render-diagrams.sh $(git ls-files '*.md')
 #
 # Rendering uses the mermaid-cli container so no host toolchain is needed.
-#   IMPORTANT: pin MMDC_IMAGE to a DIGEST (image@sha256:...), never a moving tag, so the
-#   gate is reproducible. Set the digest for your repo and commit it — this script does NOT
-#   ship a digest because a fabricated one would be worse than none (verify it yourself:
-#   `docker pull <image:tag>` then read the digest it reports).
+#   IMPORTANT: MMDC_IMAGE is pinned to a DIGEST (image@sha256:...), not a moving tag, so the gate
+#   is reproducible. The default below is a published mermaid-cli digest (tag 11.x); override it
+#   via the MMDC_IMAGE env var. When you bump it, re-pin to the exact digest `docker pull` reports
+#   for the new tag — never a fabricated one.
 MMDC_IMAGE="${MMDC_IMAGE:-ghcr.io/mermaid-js/mermaid-cli/mermaid-cli@sha256:cc56b1ed2c15f9d72ef02fe71c04d129f4291ca1ce587b9d03da8fbfbf50e072}"  # tag 11.x; bump deliberately + re-pin
 
 set -euo pipefail


### PR DESCRIPTION
## What changed
- **Two-tier `leakage-guard`.** The public `scripts/leakage-guard.sh` ships only *generic class-patterns* (a CGNAT/Tailscale IP range, Obsidian wiki-links) and sources *literal* personal identifiers from an un-committed `references/leakage-denylist.local` (new `.template`). CI enforces Tier-1; the local pre-PR run enforces both.
- **Frontmatter `description` trimmed 1587 → 979 chars** — under Anthropic's hard 1024-char limit — keeping role, languages, `Use when`, and the mode triggers; framework enumeration moved to the body.
- **`render-diagrams.sh`** comment fixed; **`evals/README`** version-token note; docs updated same-commit; version **v1.0.0 → v1.1.0**.

## Why
The old denylist had to publish a literal to block it; the frontmatter description exceeded Anthropic's limit.

## Testing
`bash scripts/leakage-guard.sh` → PASS (both tiers). Verified it FAILS on an injected CGNAT-range address (Tier-1 generic) and an injected private hostname (Tier-2 literal), that the private `.local` is git-ignored and never staged, and that CI-mode (no `.local`) passes on the clean tree. Description re-counted at 979 chars.

## Self-review
Reviewed correctness / scope / privacy — literals never enter a tracked file or git history via this change. No findings.