### PR TITLE
chore: README 'What it governs' + MAINTAINERS.md + CODEOWNERS for a second maintainer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,18 +1,17 @@
 # CODEOWNERS — documents who owns each part of the skill, and (when branch protection's
 # "require review from Code Owners" is enabled) routes review on the parts where a bad change
 # does the most harm. Every path must resolve to a user with repo access, or GitHub silently
-# skips the owner — so keep these current.
+# skips the owner — so keep these current. (@jeffols activates once the collaborator invite is
+# accepted; until then GitHub harmlessly skips that owner.)
 
-# Default owner for everything
-*                       @bjgreenberg
+# Default owner for everything — both maintainers
+*                       @bjgreenberg @jeffols
 
-# The skill's contract and its disciplines — the heart of the project
-/SKILL.md               @bjgreenberg
-/references/            @bjgreenberg
+# The skill's contract and its disciplines — the heart of the project (both maintainers)
+/SKILL.md               @bjgreenberg @jeffols
+/references/            @bjgreenberg @jeffols
 
-# Tooling that gates the repo (the leakage / render / audit checks themselves)
+# Tooling that gates the repo + CI + the regression suite — owned by the lead maintainer
 /scripts/               @bjgreenberg
 /.github/               @bjgreenberg
-
-# The regression suite that guards the disciplines
 /evals/                 @bjgreenberg

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,0 +1,20 @@
+# Maintainers
+
+This project is maintained by:
+
+- **Brian Greenberg** ([@bjgreenberg](https://github.com/bjgreenberg)) — lead maintainer · <https://briangreenberg.net>
+- **[@jeffols](https://github.com/jeffols)** — maintainer
+
+## How we work
+
+- Every change lands via a pull request with the required checks green (`docs-render`, `leakage-guard`)
+  and a maintainer review — see [CONTRIBUTING.md](CONTRIBUTING.md).
+- The branch ruleset requires **1 approving review**. The lead maintainer (repo admin) can self-merge
+  their *own* PRs via an admin bypass, so a solo merge is never blocked — while every *other*
+  contributor's PR gets a genuine four-eyes review before it lands.
+- Merges are **squash-only**. GitHub signs the squash commit, so contributions land **Verified** on
+  `main` even from unsigned feature branches — no commit-signing setup required to contribute.
+- Security reports go through **private advisories**, never public issues — see [SECURITY.md](SECURITY.md).
+
+[`.github/CODEOWNERS`](.github/CODEOWNERS) documents who owns which parts and (if "require review from
+Code Owners" is ever enabled) routes review on the sensitive paths automatically.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # senior-engineering-partner
 
-Last updated: 2026-06-29 08:07 AM CDT
+Last updated: 2026-06-29 08:12 AM CDT
 
 A custom Claude Code skill: a strict **code reviewer, pair programmer, debugger, and mentor** for
 Python, Bash, Google Apps Script, and JavaScript. It encodes a security-first,
@@ -37,6 +37,25 @@ Three ideas run through everything:
   like — it drives the loop that produces it: **spec-first** (agree what you're building
   before building it) → **plan** in verifiable steps → **tier-aware iron-law TDD** →
   **verify-before-done self-review**. Depth scales with the rigor tier; the loop does not.
+
+---
+
+## What it governs
+
+The disciplines are stack-agnostic, but they bind to concrete tooling. At a glance, what the skill
+carries standards for:
+
+- **Languages:** Python · Bash · Google Apps Script · JavaScript / TypeScript
+- **Source control & CI/CD:** GitHub · GitHub Actions · branch protection / rulesets · supply-chain gates (SBOM · SLSA · signing)
+- **Cloud & infra:** GCP / Cloud Run · Docker · Kubernetes · Terraform (IaC)
+- **Data:** Postgres / Supabase (RLS) · BigQuery · SQLite · caching
+- **App layer:** FastAPI / Python web APIs · front-end & browser security · responsive, accessible (WCAG 2.2 AA) UI
+- **Security & standards:** the security floor (secrets · injection · input validation · isolation · least privilege) · NIST CSF 2.0 + SSDF · OWASP Top 10 / **API Top 10** / **LLM Top 10** · STRIDE · SOC 2 · Well-Architected · PCI-DSS scope
+- **Reliability & ops:** resilience engineering · disaster recovery & business continuity · scalability / system design · observability + incident response (DORA · SLOs)
+- **Platform-specific:** macOS app bundles / TCC · local & agentic AI tooling · diagrams-as-code (Mermaid)
+
+Each binds to a deep, **read-on-demand** reference (see the [catalog](#reference-catalog) below); your
+concrete hosts, projects, and stack live only in the private, un-committed `references/my-environment.md`.
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -383,6 +383,7 @@ Content additions (from the evaluation's scope/security-framework findings):
 - **Named the framework mappings** the skill already implements: **OWASP LLM Top 10 (2025)** in `secure-data-processing.md` and **OWASP API Security Top 10 (2023)** (API1 BOLA ≠ web A01) in `threat-modeling-and-api-design.md`.
 - **Profile-before-you-optimize** discipline (`debugging.md`); **legacy-refactor + tech-debt register** (`engineering-workflow.md`); **systems-theory naming** — feedback loops, Senge archetypes, iceberg/Cynefin, Conway's Law, Safety-II — across the relevant references.
 - **Compliance one-liners**: PCI-DSS scope posture (`compliance.md`), NIST AI RMF / ISO 42001 pointers, and an explicit i18n non-goal (`ui-design-and-accessibility.md`).
+- **Repo/community:** README "What it governs" coverage section, a `MAINTAINERS.md`, and CODEOWNERS updated for a second maintainer (two-tier leakage model + admin-bypass review flow documented).
 
 #### v1.0.0 — 2026-06-25 — Initial public release
 - First public, sanitized release: a **stack-agnostic universal core** (`SKILL.md`, always


### PR DESCRIPTION
## What changed
- **README "What it governs"** — a scannable coverage section (languages · CI/CD · cloud/infra · data · app layer · security & standards · reliability/ops · platform-specific) right before Architecture, with a read-on-demand + private-profile note.
- **`MAINTAINERS.md`** — documents the two-maintainer model and the approvals=1 + admin-bypass review flow (solo merge never blocked; every contributor PR gets four-eyes).
- **CODEOWNERS** — `@jeffols` added as content co-owner of `SKILL.md`/`references/` (activates when the invite is accepted); the lead maintainer keeps `scripts/`, `.github/`, `evals/`.
- v1.1.0 changelog extended.

## Why
Closes the README coverage-section ask and prepares the repo for a second maintainer (jeffols).

## Testing
`bash scripts/leakage-guard.sh` → PASS. No Mermaid changes. Docs-only.

## Self-review (per repo policy)
Reviewed scope/correctness/privacy: documentation only, no behavior change, no identifiers added. CODEOWNERS `@jeffols` is inert until he accepts (noted in the file). No findings.