### PR TITLE
fix: make leakage-guard + docs-render bash 3.2-portable (drop mapfile)

### DIFF
--- a/.github/workflows/docs-render.yml
+++ b/.github/workflows/docs-render.yml
@@ -20,7 +20,9 @@ jobs:
       - name: Render every Mermaid diagram
         run: |
           set -euo pipefail
-          mapfile -t files < <(grep -rl '```mermaid' --include='*.md' . | sort)
+          files=()
+          while IFS= read -r _f; do files+=("$_f"); done \
+            < <(grep -rl '```mermaid' --include='*.md' . | sort)
           if [[ ${#files[@]} -eq 0 ]]; then echo "no mermaid blocks"; exit 0; fi
           printf 'rendering: %s\n' "${files[@]}"
           bash scripts/render-diagrams.sh "${files[@]}"

--- a/scripts/leakage-guard.sh
+++ b/scripts/leakage-guard.sh
@@ -46,7 +46,12 @@ if [[ -f "$local_list" ]]; then
 fi
 
 # Files to scan: tracked Markdown/JSON/shell, excluding this script and the private profile.
-mapfile -t files < <(
+# Portable array fill — `mapfile`/`readarray` is bash 4+, but macOS ships bash 3.2, so a
+# stock-bash run (or a non-login shell) would die with "mapfile: command not found".
+files=()
+while IFS= read -r _f; do
+  files+=("$_f")
+done < <(
   { git ls-files '*.md' '*.json' '*.sh' 2>/dev/null \
       || find . -type f \( -name '*.md' -o -name '*.json' -o -name '*.sh' \) -not -path './.git/*'; } \
     | grep -vE '^(\./)?(scripts/leakage-guard\.sh|references/my-environment\.md)$' | sort -u


### PR DESCRIPTION
## What changed
Replaced both `mapfile -t files < <(...)` calls — in `scripts/leakage-guard.sh` and the `docs-render.yml` CI step — with a portable `while IFS= read -r` array fill.

## Why
`mapfile`/`readarray` is bash 4+, but macOS ships **bash 3.2**. Running `scripts/leakage-guard.sh` with stock `/bin/bash` (or in a non-login shell — e.g. over SSH) failed with `mapfile: command not found`, so the leakage gate **silently didn't run**. Found while delivering the Tier-2 denylist to a stock-bash machine. Ironic for a Bash-standards skill; worth fixing for contributors who don't have bash 5 first in PATH.

## Testing
- `/bin/bash scripts/leakage-guard.sh` (stock **bash 3.2.57**) → **PASS** (previously errored), and still **catches an injected literal** (Tier-2 works).
- Default bash → PASS; `shellcheck scripts/leakage-guard.sh` → clean.
- No behavior change on bash 5 / CI (Ubuntu).

## Self-review (per repo policy)
Reviewed: pure portability fix, same scan set and output, no discipline/instruction change (CONTRIBUTING one-line-fix carve-out → no version bump). No findings.