### PR TITLE
feat(standards): name reuse-first, rule-of-three, and YAGNI in modular-code discipline

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -279,6 +279,9 @@ Every deliverable must be built for reuse and composability:
 - Break logic into single-responsibility functions and modules. No monolithic scripts.
 - Separate concerns: configuration, business logic, I/O, and error handling must be distinct layers.
 - Prefer functions with clear inputs and outputs over side-effect-heavy code.
+- **Reuse before you write.** Search for an existing function/utility that already does the job before adding a new one — the *don't reinvent* rule from the engineering workflow, applied at code-time. A near-duplicate (the same logic in a slightly different shape) is a refactor-to-share, not a second copy.
+- **Abstract at the second or third real caller, not the first (rule of three).** Don't extract a shared helper, base class, or generic parameter for a single call site — a premature abstraction guesses wrong about what actually varies and is harder to unwind than the duplication it replaced. Let two or three concrete callers show you the real shape of what's shared first.
+- **No speculative generality (YAGNI).** Build for the requirement in front of you, not an imagined future one — no parameters, hooks, config flags, or extension points for features nobody has asked for. Unused flexibility is dead code that still has to be read, tested, and kept correct; it's the *don't widen scope silently* rule applied to design.
 - For Python, structure projects with proper package layout (`__init__.py`, `utils/`, `config/`, etc.) where scope warrants it.
 - Write code as if someone else will maintain it — because they will.
 - **Exception: portable single-file scripts** — keep them flat but organized with clear section-header comments and TypedDicts. Apply the Single-File vs. Package decision framework above before recommending a refactor.

--- a/evals/scenarios/yagni-no-speculative-abstraction.json
+++ b/evals/scenarios/yagni-no-speculative-abstraction.json
@@ -1,0 +1,16 @@
+{
+  "skills": ["senior-engineering-partner"],
+  "query": "I need to send a Slack message when a nightly job fails. Build me a flexible notification system that can also support email, SMS, and webhooks later so I don't have to rewrite it.",
+  "files": [],
+  "expected_behavior": [
+    "Builds only the Slack path the current requirement needs (YAGNI), not a multi-channel framework for unrequested email/SMS/webhook channels",
+    "Explicitly declines to add speculative parameters/hooks/providers for features nobody has asked for yet",
+    "States that a shared abstraction is warranted at the second or third real channel (rule of three), not the first — and that extracting it now would guess wrong about what varies",
+    "Reuses any existing notification/HTTP utility rather than reinventing one, and keeps the single Slack path small and single-responsibility"
+  ],
+  "anti_behavior": [
+    "Designs a generic pluggable multi-channel notification framework (provider interface, registry, base class) for the single Slack use case",
+    "Adds email/SMS/webhook stubs, config flags, or extension points that no current requirement uses"
+  ],
+  "source": "SKILL.md MODULAR & REUSABLE CODE (reuse-first / rule-of-three / YAGNI); provenance MAOS STD-ARCH-001/002/003"
+}


### PR DESCRIPTION
## What changed
Adds three explicit bullets to the **MODULAR & REUSABLE CODE** section of `SKILL.md`:
- **Reuse before you write** — search for an existing utility before adding a new one (the *don't reinvent* rule, at code-time).
- **Abstract at the second/third real caller (rule of three)** — no shared helper/base-class/generic-param for a single call site.
- **No speculative generality (YAGNI)** — build for the requirement in front of you; no hooks/flags/extension points for unrequested features.

Plus a guarding eval: `evals/scenarios/yagni-no-speculative-abstraction.json`.

## Why it changed
The section carried a "don't reinvent" nudge but never named these three bedrock reuse/abstraction disciplines. A mechanical grep confirmed **zero** prior coverage of rule-of-three / YAGNI / speculative-generality in `SKILL.md` or `references/`. Sourced from an analysis of the external **MAOS** repo (`M-A-Operating-System/ai-coding-standards2`, standards `STD-ARCH-001/002/003`); ideas only, re-expressed in this skill's voice (MAOS is unlicensed — no verbatim copy). Ties to the existing *don't widen scope silently* ethos.

## Testing
- `bash scripts/leakage-guard.sh` → **PASS** (no environment-specific identifiers).
- New eval validated as JSON.
- Eval encodes the discipline: a "build a flexible multi-channel notification system" prompt for a single-Slack requirement must yield the Slack path only, not a speculative framework.