### PR TITLE
docs: correct stale review-model note and eval-count label to match live config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,15 +105,19 @@ may not be checkable enough yet.
   your contribution lands **Verified** on `main` even if your own commits weren't signed; you don't
   need to set up signing.
 
-> **A note on the "0 required reviews" setting.** The branch ruleset doesn't *mechanically* require
-> an approval. That's a deliberate accommodation so the solo maintainer can merge their own work
-> (where a documented self-review stands in for a second reviewer). It is **not** a waiver:
-> **contributor PRs are reviewed by a maintainer as a matter of policy** before they land. This
-> mirrors the skill's own rule — *your own hand-written change, green checks suffice; someone
-> else's change, a human reviews it* (`references/github-teams.md` §3).
+> **A note on the review requirement.** The branch ruleset **requires one approving review**, and the
+> maintainer (the repository-admin role) is a **bypass actor** — so the two cases resolve cleanly. A
+> **contributor PR** lands the normal way: on a maintainer's approving review. The **maintainer's own
+> PR** can't be self-approved (GitHub forbids approving your own PR), so it merges via **admin bypass
+> after a documented self-review** — recorded in the PR — stands in for the second reviewer. This is
+> **not** a waiver of review: every PR is reviewed; the bypass only covers the mechanical
+> can't-approve-your-own-PR case. It mirrors the skill's own rule — *your own hand-written change,
+> green checks + a recorded self-review suffice; someone else's change, a human reviews it*
+> (`references/github-teams.md` §3).
 
-[`CODEOWNERS`](.github/CODEOWNERS) documents who owns which parts of the skill; if required reviews
-are ever turned on, it routes review automatically on the sensitive paths.
+[`CODEOWNERS`](.github/CODEOWNERS) documents who owns which parts of the skill. Code-owner review is
+**not** required in the ruleset today (`require_code_owner_review` is off), so `CODEOWNERS` is advisory
+— enabling it would route review automatically on the sensitive paths.
 
 ## Code of Conduct
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # senior-engineering-partner
 
-Last updated: 2026-06-30 07:19 PM CDT
+Last updated: 2026-06-30 07:24 PM CDT
 
 A custom Claude Code skill: a strict **code reviewer, pair programmer, debugger, and mentor** for
 Python, Bash, Google Apps Script, and JavaScript. It encodes a security-first,
@@ -74,7 +74,7 @@ flowchart TD
     U["/senior-engineering-partner"] --> C
     C["SKILL.md — universal core<br/>modes · epistemic discipline · engineering workflow · rigor ladder<br/>security floor · coding standards · toolchain triggers"]
     C -->|"progressive disclosure: read a reference only when relevant"| R[(references/)]
-    C -.->|"shipped helpers"| K["scripts/ (audit · render-diagrams · self-review)<br/>evals/ (19 regression scenarios)"]
+    C -.->|"shipped helpers"| K["scripts/ (audit · render-diagrams · self-review)<br/>evals/ (27 regression scenarios)"]
     R --> P["Environment profile<br/>my-environment.md (swap to re-home the skill)"]
     R --> W["Engineering process (2)<br/>engineering-workflow · debugging"]
     R --> S["Security, privacy and compliance (6)"]


### PR DESCRIPTION
## What changed
- **`CONTRIBUTING.md`** — rewrites the "0 required reviews" note and the CODEOWNERS sentence to match the **live ruleset**: 1 approving review required; the maintainer's own PR merges via **admin bypass after a recorded self-review** (can't self-approve); `require_code_owner_review` is off, so CODEOWNERS is advisory today.
- **`README.md`** — corrects the architecture-diagram eval-count label **19 → 27** (stale by a pre-existing 3, plus this series' 5 new scenarios) and bumps the `Last updated:` stamp.

## Why it changed
Surfaced while merging this series: the live `main-protection` ruleset has `required_approving_review_count: 1`, but CONTRIBUTING still described a 0-approval self-merge model. **MAINTAINERS.md was already correct** (1 review + admin self-merge); this aligns CONTRIBUTING with it. Grade-from-live-config over grade-from-docs — the skill's own `AUDIT` discipline, applied to itself.

## Testing
- `bash scripts/render-diagrams.sh README.md` → **all 3 blocks render cleanly** (the count label lives inside a Mermaid node).
- `bash scripts/leakage-guard.sh` → **PASS**.
- `git grep` swept the tree for other stale copies: the remaining "approvals at 0 / self-merge" mentions (`github-teams.md`, `SKILL.md` SCM) are the skill's *general* solo-team teaching, not claims about this repo — deliberately left as-is.