### PR TITLE
docs: correct stale reference group counts in the README architecture diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # senior-engineering-partner
 
-Last updated: 2026-06-30 07:24 PM CDT
+Last updated: 2026-06-30 07:31 PM CDT
 
 A custom Claude Code skill: a strict **code reviewer, pair programmer, debugger, and mentor** for
 Python, Bash, Google Apps Script, and JavaScript. It encodes a security-first,
@@ -76,11 +76,11 @@ flowchart TD
     C -->|"progressive disclosure: read a reference only when relevant"| R[(references/)]
     C -.->|"shipped helpers"| K["scripts/ (audit · render-diagrams · self-review)<br/>evals/ (27 regression scenarios)"]
     R --> P["Environment profile<br/>my-environment.md (swap to re-home the skill)"]
-    R --> W["Engineering process (2)<br/>engineering-workflow · debugging"]
+    R --> W["Engineering process (3)<br/>engineering-workflow · debugging · standards-authoring"]
     R --> S["Security, privacy and compliance (6)"]
     R --> T["Testing and QA (2)"]
-    R --> I["Cloud, infra and ops (6) + data (2)"]
-    R --> A["App toolchains, CI and collaboration (9)"]
+    R --> I["Cloud, infra and ops (9) + data (2)"]
+    R --> A["App toolchains, CI and collaboration (11)"]
     R --> X["UI, a11y, diagrams, AI tooling, macOS (4)"]
 ```
 


### PR DESCRIPTION
## What changed
Corrects three drifted group counts in the README **architecture** Mermaid diagram so it matches the reference-catalog table (the authoritative enumeration):
- **Engineering process (2) → (3)** and now lists the new member `standards-authoring` — the diagram half of #22 that the PR missed.
- **Cloud, infra and ops (6) → (9)** — pre-existing drift.
- **App toolchains, CI & collaboration (9) → (11)** — pre-existing drift.

## Why it changed
Follow-up to the MAOS-incorporation series (#18–#23): a same-commit-docs sweep found the architecture diagram understating the reference counts. "A stale diagram is a wrong diagram" (the skill's own rule) — so the counts are brought current. Diagram category counts now sum to the catalog exactly (37 categorised + 1 environment profile = 38 rows).

## Testing
- `bash scripts/render-diagrams.sh README.md` → **all 3 blocks render cleanly**.
- `bash scripts/leakage-guard.sh` → **PASS**.
- Counts verified programmatically against the catalog table.

## Noted (not fixed here)
`references/audit-report-format.md` (the AUDIT-mode format) is a real reference not listed in the catalog table or diagram — a **pre-existing** omission, unrelated to this series. Left as-is pending a categorization decision rather than silently recategorized.