### PR TITLE
docs(maintainers): document the release-PR label flip that unsticks the next release

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -40,9 +40,20 @@ bumps the `Version` in [`SKILL.md`](SKILL.md) and prepends the new section to
    gh release create "v$VERSION" --verify-tag --title "v$VERSION" \
      --notes "$(awk "/^## \[$VERSION\]/{f=1;print;next} /^## \[/{f=0} f" CHANGELOG.md)"
    ```
-   On its next run release-please reads the `vX.Y.Z` tag as the release marker and starts
-   accumulating the following version. (Signing on a remote/locked machine: see the project's
-   own commit-signing notes — squash-merge web-signs `main`, but the *tag* must be signed locally.)
+   (Signing on a remote/locked machine: see the project's own commit-signing notes — squash-merge
+   web-signs `main`, but the *tag* must be signed locally.)
+4. **Flip the release PR's label — or the next release is silently blocked.** release-please tracks
+   release state by **PR label, not by the git tag**. With `skip-github-release: true` it never marks
+   the merged release PR as released, so every subsequent run **aborts** with *"There are untagged,
+   merged release PRs outstanding"* and opens no new release PR until you relabel it. After the tag +
+   Release are cut, move the merged release PR from `autorelease: pending` to `autorelease: tagged`:
+   ```bash
+   gh pr edit <release-pr#> --add-label "autorelease: tagged" --remove-label "autorelease: pending"
+   ```
+   (Create the `autorelease: tagged` label once if the repo doesn't have it.) Only then does
+   release-please treat `vX.Y.Z` as the baseline and start accumulating the next version.
+   *(Learned the hard way: the 1.5.0 release PR stayed `autorelease: pending` and silently blocked the
+   1.6.0 release PR across six green workflow runs until it was relabeled.)*
 
 [`.github/CODEOWNERS`](.github/CODEOWNERS) documents who owns which parts and (if "require review from
 Code Owners" is ever enabled) routes review on the sensitive paths automatically.


### PR DESCRIPTION
## What changed
Adds **step 4** to `MAINTAINERS.md` → *Cutting a release*: after cutting the signed tag + Release, flip the merged release PR from `autorelease: pending` to `autorelease: tagged`. Corrects the misleading claim that release-please "reads the vX.Y.Z tag as the release marker."

## Why it changed
release-please with `skip-github-release: true` tracks release state by **PR label, not the git tag**. A merged release PR left `autorelease: pending` makes every subsequent run abort with *"There are untagged, merged release PRs outstanding"* — opening no new release PR. This silently blocked **1.6.0 across six green runs** until PR #17 (release 1.5.0) was relabelled. Documenting the flip prevents recurrence — root-cause fix + docs, per the skill's own discipline.

## Testing
- `bash scripts/leakage-guard.sh` → **PASS**. No diagrams touched.
- Validated live this session: relabeling #17 immediately unstuck release-please (it opened the 1.6.0 PR); #26 was proactively flipped to `autorelease: tagged` after the v1.6.0 cut.