### PR TITLE
docs: remove @jeffols from the maintainer listing and CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,17 +1,16 @@
 # CODEOWNERS — documents who owns each part of the skill, and (when branch protection's
 # "require review from Code Owners" is enabled) routes review on the parts where a bad change
 # does the most harm. Every path must resolve to a user with repo access, or GitHub silently
-# skips the owner — so keep these current. (@jeffols activates once the collaborator invite is
-# accepted; until then GitHub harmlessly skips that owner.)
+# skips the owner — so keep these current.
 
-# Default owner for everything — both maintainers
-*                       @bjgreenberg @jeffols
+# Default owner for everything
+*                       @bjgreenberg
 
-# The skill's contract and its disciplines — the heart of the project (both maintainers)
-/SKILL.md               @bjgreenberg @jeffols
-/references/            @bjgreenberg @jeffols
+# The skill's contract and its disciplines — the heart of the project
+/SKILL.md               @bjgreenberg
+/references/            @bjgreenberg
 
-# Tooling that gates the repo + CI + the regression suite — owned by the lead maintainer
+# Tooling that gates the repo + CI + the regression suite
 /scripts/               @bjgreenberg
 /.github/               @bjgreenberg
 /evals/                 @bjgreenberg

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -2,14 +2,13 @@
 
 This project is maintained by:
 
-- **Brian Greenberg** ([@bjgreenberg](https://github.com/bjgreenberg)) — lead maintainer · <https://briangreenberg.net>
-- **[@jeffols](https://github.com/jeffols)** — maintainer
+- **Brian Greenberg** ([@bjgreenberg](https://github.com/bjgreenberg)) — maintainer · <https://briangreenberg.net>
 
 ## How we work
 
 - Every change lands via a pull request with the required checks green (`docs-render`, `leakage-guard`)
   and a maintainer review — see [CONTRIBUTING.md](CONTRIBUTING.md).
-- The branch ruleset requires **1 approving review**. The lead maintainer (repo admin) can self-merge
+- The branch ruleset requires **1 approving review**. The maintainer (repo admin) can self-merge
   their *own* PRs via an admin bypass, so a solo merge is never blocked — while every *other*
   contributor's PR gets a genuine four-eyes review before it lands.
 - Merges are **squash-only**. GitHub signs the squash commit, so contributions land **Verified** on


### PR DESCRIPTION
## What changed
- **`MAINTAINERS.md`** — removes `@jeffols` from the maintainer list; Brian is the sole listed maintainer ("lead maintainer" → "maintainer").
- **`.github/CODEOWNERS`** — removes `@jeffols` from all ownership rules and the activation comment; neutralizes the "both maintainers" phrasing. All paths now resolve to `@bjgreenberg`; the granular structure is kept for when a second maintainer joins.

## Why it changed
Per maintainer direction. **Documentation only** — jeffols's collaborator (write) access is intentionally left untouched.

## Testing
- `git grep jeffols` → clean outside CHANGELOG history.
- `bash scripts/leakage-guard.sh` → **PASS**. No diagrams touched.