### PR TITLE
docs(readme): add honest status/metadata badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,12 @@
 # senior-engineering-partner
 
-Last updated: 2026-06-30 07:40 PM CDT
+Last updated: 2026-06-30 10:16 PM CDT
+
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![Latest release](https://img.shields.io/github/v/release/bjgreenberg/senior-engineering-partner?sort=semver&label=release)](https://github.com/bjgreenberg/senior-engineering-partner/releases)
+[![docs-render](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/docs-render.yml/badge.svg?branch=main)](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/docs-render.yml)
+[![leakage-guard](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/leakage-guard.yml/badge.svg?branch=main)](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/leakage-guard.yml)
+[![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://www.conventionalcommits.org/en/v1.0.0/)
 
 A custom Claude Code skill: a strict **code reviewer, pair programmer, debugger, and mentor** for
 Python, Bash, Google Apps Script, and JavaScript. It encodes a security-first,


### PR DESCRIPTION
## What changed
Adds a badge row under the title (below the `Last updated` stamp, which stays directly under the H1 per the skill's own README rule):
- **License** Apache-2.0 · **Latest release** (auto, shows v1.6.0) · **docs-render** (live CI) · **leakage-guard** (live CI) · **Conventional Commits**.

## Why it changed
At-a-glance signals for a public repo. Only badges that are **true and live** — a false badge is the stale-claim anti-pattern the skill warns against. Deliberately **omitted**: "tests passing" (evals are LLM-judged, no pytest suite), coverage (none), SLSA/SBOM (prose repo, no built artifact), PyPI/npm (not a package), python-version matrix (it's a skill).

## Testing
- All badge endpoints verified **HTTP 200** (both Actions badges + shields release).
- `bash scripts/leakage-guard.sh` → PASS · `render-diagrams.sh README.md` → 3/3 render clean.