### PR TITLE
fix(ci): minimal scorecard workflow — drop SARIF upload that broke publish

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,8 +1,10 @@
 # OpenSSF Scorecard — supply-chain / security-posture analysis.
-# Publishes a score to https://api.securityscorecards.dev (public) that the README badge reads,
-# and uploads SARIF to the repo's code-scanning tab. On-brand: `references/foss-adoption.md` tells
-# users to check a dependency's Scorecard before adopting it — this runs it on our own repo.
-# Third-party actions are SHA-pinned (SKILL.md supply-chain rule); the trailing comment is the version.
+# Publishes a score to https://api.securityscorecards.dev (public) that the README badge reads.
+# On-brand: `references/foss-adoption.md` tells users to check a dependency's Scorecard before
+# adopting it — this runs it on our own repo. Minimal by design: only `checkout` + `scorecard-action`.
+# (The SARIF→code-scanning upload was dropped — it's optional for the badge, and scorecard's publish
+# workflow-verification rejected the codeql-action pin as an "imposter commit"; fewer actions = less
+# surface, per SKILL.md.) Third-party actions are SHA-pinned; the trailing comment is the version.
 name: scorecard
 
 on:
@@ -13,8 +15,8 @@ on:
     branches: [ "main" ]
 
 # scorecard reads many repo APIs (branch protection, webhooks, workflow perms); it needs broad
-# READ. Write scopes are elevated only in the job that needs them. (Documented deviation from the
-# default `contents: read`, per SKILL.md's "an undocumented skip is a hidden waiver".)
+# READ. The one write scope is elevated only in the job that needs it. (Documented deviation from
+# the default `contents: read`, per SKILL.md's "an undocumented skip is a hidden waiver".)
 permissions: read-all
 
 jobs:
@@ -22,7 +24,6 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      security-events: write     # upload the SARIF result to code-scanning
       id-token: write            # OIDC — publish the result to the OpenSSF API (for the badge)
     steps:
       - name: Checkout code
@@ -36,15 +37,3 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true   # required for the public badge
-
-      - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: SARIF file
-          path: results.sarif
-          retention-days: 5
-
-      - name: Upload to code-scanning
-        uses: github/codeql-action/upload-sarif@411bbbe57033eedfc1a82d68c01345aa96c737d7 # v4
-        with:
-          sarif_file: results.sarif


### PR DESCRIPTION
## What changed
Trims `scorecard.yml` to the minimal **checkout + scorecard-action** (drops the optional `upload-artifact` and `github/codeql-action/upload-sarif` steps, and the now-unneeded `security-events: write`).

## Why it changed
The first run's analysis succeeded but the **publish to the OpenSSF API failed (HTTP 400)**: `imposter commit: 411bbbe… does not belong to github/codeql-action/upload-sarif` — scorecard's publish-time workflow verification rejected that action's pin. The SARIF→code-scanning upload is optional for the badge, so removing it fixes the publish and shrinks the third-party action surface (on-brand).

## Testing
- YAML validated (ruby); `leakage-guard` PASS.
- On merge, the push-to-`main` run should publish; I'll verify the score before adding the badge.