### PR TITLE
fix(ci): scope release-please write permissions to the job (least privilege)

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -20,13 +20,17 @@ on:
   push:
     branches: [main]
 
+# Least privilege: read-only at the top level; the write scopes release-please needs to open
+# its release PR are granted only on the job that uses them (OpenSSF Scorecard Token-Permissions).
 permissions:
-  contents: write
-  pull-requests: write
+  contents: read
 
 jobs:
   release-please:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write         # push the release branch + tags
+      pull-requests: write    # open/update the release PR
     steps:
       - uses: googleapis/release-please-action@5c625bfb5d1ff62eadeeb3772007f7f66fdcf071 # v4.4.1
         with:


### PR DESCRIPTION
## What changed
`release-please.yml`: top-level `permissions` → `contents: read`; the `contents: write` + `pull-requests: write` release-please needs are moved to the **job** level.

## Why it changed
OpenSSF Scorecard's **Token-Permissions** check scored **0 (High)** because write scopes were declared at the top level. This is the recommended least-priv pattern — and the skill's *own* `github-actions.md` rule ("explicit least-priv permissions, default `contents: read`, write at the job level"), so it was a self-inconsistency. Functionally identical for release-please; improves the live Scorecard score the badge reads.

## Testing
- YAML validated (ruby); `leakage-guard` PASS.
- release-please's job retains exactly the scopes it needs (push release branch/tags, open the PR). The next scorecard run (on this merge) will re-score Token-Permissions.