### PR TITLE
docs(readme): add the live OpenSSF Scorecard badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # senior-engineering-partner
 
-Last updated: 2026-06-30 10:16 PM CDT
+Last updated: 2026-06-30 10:37 PM CDT
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/bjgreenberg/senior-engineering-partner?sort=semver&label=release)](https://github.com/bjgreenberg/senior-engineering-partner/releases)
 [![docs-render](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/docs-render.yml/badge.svg?branch=main)](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/docs-render.yml)
 [![leakage-guard](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/leakage-guard.yml/badge.svg?branch=main)](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/leakage-guard.yml)
+[![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/bjgreenberg/senior-engineering-partner/badge)](https://scorecard.dev/viewer/?uri=github.com/bjgreenberg/senior-engineering-partner)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://www.conventionalcommits.org/en/v1.0.0/)
 
 A custom Claude Code skill: a strict **code reviewer, pair programmer, debugger, and mentor** for


### PR DESCRIPTION
## What changed
Adds the **OpenSSF Scorecard** badge to the README badge row (links to the public scorecard viewer).

## Why it changed
Completes the compliance-badge work: the Scorecard workflow now publishes a real score, so the badge is **honest and live** — added only *after* verifying the endpoint returns a score (no "unknown" badge, per the honest-badges rule this repo now teaches). It auto-updates each run, so the Token-Permissions least-priv fix (#34) will lift it.

## Testing
- Badge SVG resolves **HTTP 200** (`image/svg+xml`); score published (6.2, updating). Viewer link resolves.
- `leakage-guard` PASS; `render-diagrams.sh README.md` 3/3 clean.