### PR TITLE
ci: add a shellcheck gate for the helper scripts

### DIFF
--- a/.github/workflows/shellcheck.yml
+++ b/.github/workflows/shellcheck.yml
@@ -1,0 +1,36 @@
+name: shellcheck
+
+# Lint the helper scripts with ShellCheck. A shell script that trips ShellCheck is a broken
+# deliverable — like a failing test — so it must not merge. This is the "enable available
+# warning flags" gate (SKILL.md CODING STANDARDS + SECURITY CHECKS: "Zero warnings is the
+# standard"), and it satisfies the OpenSSF Best Practices `warnings` criterion with a real
+# check instead of a justification.
+#
+# No third-party action: ShellCheck is pre-installed on the ubuntu-latest runner, so this uses
+# only the repo's already-SHA-pinned checkout + a run step (fewer actions = less surface, the
+# same posture as scorecard.yml).
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  shellcheck:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Lint helper scripts
+        run: |
+          set -euo pipefail
+          shellcheck --version
+          files=()
+          while IFS= read -r _f; do files+=("$_f"); done \
+            < <(find scripts -name '*.sh' -type f | sort)
+          if [[ ${#files[@]} -eq 0 ]]; then echo "no shell scripts"; exit 0; fi
+          printf 'linting: %s\n' "${files[@]}"
+          shellcheck "${files[@]}"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,9 +59,10 @@ regular collaborators use a branch on the repo. Either way:
    names / email to their own local denylist.
 7. **If you encode a discipline, guard it with an eval.** New or changed rules should add or extend
    a scenario in `evals/` — the project's "changelog is the spec, evals are the tests" model.
-8. **Run the gates locally** before opening the PR: `bash scripts/leakage-guard.sh` and
-   `bash scripts/render-diagrams.sh` (render-check any Mermaid you touched). Locally-green is
-   necessary but **not sufficient** — the PR's required checks are the source of truth.
+8. **Run the gates locally** before opening the PR: `bash scripts/leakage-guard.sh`,
+   `bash scripts/render-diagrams.sh` (render-check any Mermaid you touched), and — if you touched a
+   helper script — `shellcheck scripts/*.sh`. Locally-green is necessary but **not sufficient** —
+   the PR's required checks are the source of truth.
 9. **Open the PR** with the **What changed / Why it changed / Testing** description (the PR template
    gives you the shape). Open it as a **draft** while it's WIP so CI runs but it can't merge early;
    mark it ready when it is. Link the issue it closes (`Closes #N`).
@@ -99,7 +100,7 @@ may not be checkable enough yet.
   every review thread addressed or resolved. We don't merge on green CI alone: green proves the
   *gates* passed, not that the change is correct, in-scope, and free of a subtle regression a check
   didn't cover.
-- The repo's **required checks** (`docs-render`, `leakage-guard`) must pass.
+- The repo's **required checks** (`docs-render`, `leakage-guard`, `shellcheck`) must pass.
 - Merges are **squash-only** — rebase-merge (it rewrites your commits *unsigned*) and merge-commit
   are both disabled — and the branch is auto-deleted on merge. GitHub signs the squash commit, so
   your contribution lands **Verified** on `main` even if your own commits weren't signed; you don't

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -6,8 +6,8 @@ This project is maintained by:
 
 ## How we work
 
-- Every change lands via a pull request with the required checks green (`docs-render`, `leakage-guard`)
-  and a maintainer review — see [CONTRIBUTING.md](CONTRIBUTING.md).
+- Every change lands via a pull request with the required checks green (`docs-render`, `leakage-guard`,
+  `shellcheck`) and a maintainer review — see [CONTRIBUTING.md](CONTRIBUTING.md).
 - The branch ruleset requires **1 approving review**. The maintainer (repo admin) can self-merge
   their *own* PRs via an admin bypass, so a solo merge is never blocked — while every *other*
   contributor's PR gets a genuine four-eyes review before it lands.
@@ -28,7 +28,7 @@ bumps the `Version` in [`SKILL.md`](SKILL.md) and prepends the new section to
 1. **Enrich the changelog.** In the open release PR, edit the new `CHANGELOG.md` section to add the
    curated "what + **why**" narrative (the prose this skill values), then mark the PR ready.
 2. **Merge the release PR.** Because release-please authored it with `GITHUB_TOKEN`, the
-   `leakage-guard` / `docs-render` checks don't auto-run on it; review the (generated) diff and
+   `leakage-guard` / `docs-render` / `shellcheck` checks don't auto-run on it; review the (generated) diff and
    admin-merge: `gh pr merge --squash --admin`.
 3. **Cut the signed tag + GitHub Release** from the merged `main`:
    ```bash

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # senior-engineering-partner
 
-Last updated: 2026-06-30 10:37 PM CDT
+Last updated: 2026-07-01 11:09 AM CDT
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/bjgreenberg/senior-engineering-partner?sort=semver&label=release)](https://github.com/bjgreenberg/senior-engineering-partner/releases)
 [![docs-render](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/docs-render.yml/badge.svg?branch=main)](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/docs-render.yml)
 [![leakage-guard](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/leakage-guard.yml/badge.svg?branch=main)](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/leakage-guard.yml)
+[![shellcheck](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/shellcheck.yml/badge.svg?branch=main)](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/shellcheck.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/bjgreenberg/senior-engineering-partner/badge)](https://scorecard.dev/viewer/?uri=github.com/bjgreenberg/senior-engineering-partner)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://www.conventionalcommits.org/en/v1.0.0/)
 
@@ -262,6 +263,9 @@ environment-specific claim**, so the more complete it is, the more grounded the 
   `@mermaid-js/mermaid-cli` (`mmdc`) — see
   [`references/diagrams-and-visual-docs.md`](references/diagrams-and-visual-docs.md). CI
   runs `scripts/render-diagrams.sh` (the `docs-render` gate) on every PR.
+- **Helper scripts are ShellCheck-clean:** a `shellcheck` gate lints `scripts/*.sh` on every PR
+  (the skill's own "zero warnings is the standard" applied to itself). A script that trips
+  ShellCheck is a broken deliverable and can't merge.
 - **No environment-specific leakage in the core:** a `leakage-guard` check greps the tree against
   a denylist of personal/host/repo identifiers. It's **two-tier**: generic class-patterns (a
   CGNAT/Tailscale IP range, Obsidian-style wiki-links) ship in `scripts/leakage-guard.sh` and run in CI,


### PR DESCRIPTION
## What changed

Adds a **`shellcheck`** CI gate that lints `scripts/*.sh` on every PR, plus the docs that describe the gate set.

- **`.github/workflows/shellcheck.yml`** — new gate. **No third-party action:** ShellCheck is pre-installed on `ubuntu-latest`, so the job is just the repo's already-SHA-pinned `actions/checkout@…v7.0.0` + a `run` step (`fewer actions = less surface`, matching `scorecard.yml`). `contents: read` only.
- **`README.md`** — `shellcheck` badge in the row + a bullet in the CI-gates section; `Last updated` stamp bumped.
- **`CONTRIBUTING.md` / `MAINTAINERS.md`** — required-checks list is now `docs-render` / `leakage-guard` / `shellcheck` (incl. the release-PR note).

## Why it changed

Turns the OpenSSF Best Practices **`warnings`** criterion from a *justification* ("scripts are ShellCheck-clean") into a real, enforced check — and applies the skill's own "zero warnings is the standard" (SKILL.md CODING STANDARDS / SECURITY CHECKS) to itself. Strengthens the Scorecard SAST posture at the same time.

## Testing / verification

- `shellcheck scripts/*.sh` → **clean (exit 0)** locally (ShellCheck 0.11.0); all three scripts already pass, so this gate is green from day one, not a backlog.
- `leakage-guard.sh` → `PASS` locally.
- No Mermaid touched (docs-render unaffected).
- CHANGELOG/Version left to release-please (this `ci:` title becomes the changelog line).

## Follow-up (maintainer)

After this lands green on `main`, promote **`shellcheck`** to a **required** status check in the `main-protection` ruleset (so the docs' "required checks" claim is true). I can do that via the API on your go, or you can toggle it — the docs already name it required.

## Self-review (no bot reviewer configured)

- **Correctness:** workflow mirrors the proven `docs-render.yml` shape; glob handled via `find … -print`-style array build (ShellCheck-safe), `set -euo pipefail`, empty-list guard. Same checkout SHA as the other workflows.
- **Supply-chain:** zero new third-party actions; least-privilege `contents: read`.
- **Docs lockstep:** every place that lists the required-check pair now lists the trio; badge is live (`badge.svg`), honest once it runs on main.