### PR TITLE
docs: add the OpenSSF Best Practices passing badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # senior-engineering-partner
 
-Last updated: 2026-07-01 11:09 AM CDT
+Last updated: 2026-07-01 01:14 PM CDT
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/bjgreenberg/senior-engineering-partner?sort=semver&label=release)](https://github.com/bjgreenberg/senior-engineering-partner/releases)
@@ -8,6 +8,7 @@ Last updated: 2026-07-01 11:09 AM CDT
 [![leakage-guard](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/leakage-guard.yml/badge.svg?branch=main)](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/leakage-guard.yml)
 [![shellcheck](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/shellcheck.yml/badge.svg?branch=main)](https://github.com/bjgreenberg/senior-engineering-partner/actions/workflows/shellcheck.yml)
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/bjgreenberg/senior-engineering-partner/badge)](https://scorecard.dev/viewer/?uri=github.com/bjgreenberg/senior-engineering-partner)
+[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13458/badge)](https://www.bestpractices.dev/projects/13458)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-yellow.svg)](https://www.conventionalcommits.org/en/v1.0.0/)
 
 A custom Claude Code skill: a strict **code reviewer, pair programmer, debugger, and mentor** for


### PR DESCRIPTION
## What changed

Adds the **OpenSSF Best Practices (CII) passing badge** to the README badge row, next to the OpenSSF Scorecard badge.

```markdown
[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/13458/badge)](https://www.bestpractices.dev/projects/13458)
```

## Why it changed

The project reached the OpenSSF Best Practices **passing** tier today (project 13458). This closes the one remaining legitimate lever on the OpenSSF Scorecard (`CII-Best-Practices`, previously 0).

## Honest-badge verification (per SKILL.md required-/honest-badges rule)

- `achieved_passing_at` = `2026-07-01T18:11:32Z` (non-null → genuinely passing), `badge_percentage_0` = 100.
- Badge endpoint `https://www.bestpractices.dev/projects/13458/badge` → **HTTP 200**, renders **"passing"**.
- The badge is **dynamic** — it self-reports the true current level (in progress → passing → silver → gold), so it can't drift into a false claim.

## Testing

- `leakage-guard.sh` → `PASS` locally.
- README `Last updated` stamp bumped in the same commit.