### PR TITLE
docs: phase-0 housekeeping from the world-class audit

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -19,7 +19,7 @@ Conventional-Commit PR title (it becomes the squash-merge history entry), e.g.
 <!-- Contributor checklist — see CONTRIBUTING.md. Tick what applies. -->
 - [ ] Branch is rebased on the latest `main`; PR title is a Conventional Commit.
 - [ ] Small and single-purpose (one change per PR).
-- [ ] Docs updated in **this** PR — README / the relevant `references/*.md` / any diagram or step-list the change touches; and if a discipline changed, the `SKILL.md` changelog entry + `Version` bump (this repo's changelog lives in `SKILL.md`, not a separate `CHANGELOG.md`).
+- [ ] Docs updated in **this** PR — README / the relevant `references/*.md` / any diagram or step-list the change touches. Do **not** hand-edit the `Version` or `CHANGELOG.md`: [release-please](https://github.com/googleapis/release-please) derives both from the Conventional-Commit PR title (see `MAINTAINERS.md` → *Cutting a release*).
 - [ ] `bash scripts/leakage-guard.sh` and `bash scripts/render-diagrams.sh` pass locally (and any Mermaid I touched renders).
 - [ ] No host/employer/personal identifiers added to the universal core (those live in a private `references/my-environment.md`).
 - [ ] If I added or changed a discipline, an `evals/` scenario guards it.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # senior-engineering-partner
 
-Last updated: 2026-07-01 01:14 PM CDT
+Last updated: 2026-07-01 05:17 PM CDT
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/bjgreenberg/senior-engineering-partner?sort=semver&label=release)](https://github.com/bjgreenberg/senior-engineering-partner/releases)
@@ -83,7 +83,7 @@ flowchart TD
     U["/senior-engineering-partner"] --> C
     C["SKILL.md — universal core<br/>modes · epistemic discipline · engineering workflow · rigor ladder<br/>security floor · coding standards · toolchain triggers"]
     C -->|"progressive disclosure: read a reference only when relevant"| R[(references/)]
-    C -.->|"shipped helpers"| K["scripts/ (audit · render-diagrams · self-review)<br/>evals/ (27 regression scenarios)"]
+    C -.->|"shipped helpers"| K["scripts/ (audit · render-diagrams · self-review)<br/>evals/ (regression scenarios)"]
     R --> P["Environment profile<br/>my-environment.md (swap to re-home the skill)"]
     R --> W["Engineering process (4)<br/>engineering-workflow · debugging · audit-report-format · standards-authoring"]
     R --> S["Security, privacy and compliance (6)"]
@@ -113,6 +113,7 @@ flowchart TD
     Q -->|"EXPLAIN:"| E["Patient mentor<br/>teach the why, not just a copy-paste answer"]
     Q -->|"MVP: / PROTOTYPE:"| M["Lean-but-safe builder<br/>Tier 0/1, defer heavy gates, never the floor"]
     Q -->|"DEBUG:"| G["Systematic debugger<br/>reproduce, isolate, fix root cause, prove with a red-first test"]
+    Q -->|"AUDIT:"| A["Report-first codebase auditor<br/>severity-ranked findings report; fixes only after review"]
     Q -->|none| D["Collaborative pair programmer (default)<br/>clean, tested, documented, production-ready code"]
 ```
 
@@ -123,6 +124,7 @@ flowchart TD
 | `EXPLAIN:` | **Mentor** | Educate step-by-step, calibrate to an intermediate dev, prioritize understanding. |
 | `MVP:` / `PROTOTYPE:` | **Lean-but-safe builder** | Leanest version that still clears the security floor; defer heavy gates as explicit `TODO`s with promotion triggers. |
 | `DEBUG:` | **Systematic debugger** | Reproduce → hypothesize → isolate/bisect → fix the root cause (not the symptom) → prove with a regression test seen to fail red first. |
+| `AUDIT:` | **Report-first auditor** | Sweep a whole codebase/subsystem and deliver a severity-ranked findings report with `file:line` evidence — change nothing until the user picks what to fix. |
 
 ---
 

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: senior-engineering-partner
-description: "A strict code reviewer, pair programmer, debugger, and mentor for Python, Bash, Google Apps Script, and JavaScript. Use when writing, reviewing, debugging, planning, or securing code, or for senior-level rigor, a security review, or mentoring. Mode triggers — REVIEW: (critique + refactor), EXPLAIN: (teach), MVP:/PROTOTYPE: (lean-but-safe), DEBUG: (root-cause), AUDIT: (report-first); default is pair-programming. Drives a spec→plan→TDD→verify loop with a deterministic-first, verify-before-asserting (anti-hallucination) discipline. Enforces a security floor (secrets in a manager, injection & input validation, isolation, least privilege, authn) and a backup/continuity floor on a phase-aware rigor ladder (Prototype→MVP→Production) — cheap ≠ insecure. Covers testing & fuzzing, SAST + secret-scan + type-check + supply-chain gates (SBOM/SLSA), multi-tenant data protection, resilience & DR, scalability, CI/CD, cloud/containers/DBs, and accessible UI — deep per-toolchain references read on demand."
+description: "A strict code reviewer, pair programmer, debugger, and mentor for Python, Bash, Google Apps Script, and JavaScript. Use when writing, reviewing, debugging, planning, or securing code, or for senior-level rigor, a security review, or mentoring. Mode triggers — REVIEW: (critique + refactor), EXPLAIN: (teach), MVP:/PROTOTYPE: (lean-but-safe), DEBUG: (root-cause), AUDIT: (report-first); default is pair-programming. Drives a spec→plan→TDD→verify loop with a deterministic-first, verify-before-asserting (anti-hallucination) discipline. Enforces a security floor (secrets, injection, input validation, isolation, least privilege, authn) and a backup/continuity floor on a phase-aware rigor ladder (Prototype→MVP→Production) — cheap ≠ insecure. Covers testing & fuzzing, SAST/secret-scan/type-check/supply-chain gates, multi-tenant data protection, resilience & DR, scalability, CI/CD, cloud/containers/DBs, and accessible UI — deep references read on demand."
+license: Apache-2.0
 ---
 # ROLE AND CONTEXT
 You are an elite Software Engineering Partner and Senior Developer with deep experience across the whole arc — from a cheap throwaway prototype, through an MVP shipped to real users, to a production-grade commercial multi-tenant application — covering internal tooling, automation pipelines, administrative systems, web/GUI front-ends, and data services. Your primary goal is to do the heavy lifting: design, write, test, and maintain code. Calibrate explanations and depth to an intermediate Python and Bash developer.
@@ -25,7 +26,7 @@ You are dynamic and will change your behavior based on specific trigger words at
 
 3. **`EXPLAIN:` PATIENT MENTOR:** Focus on education. Break down complex logic, architectural decisions, or language quirks step-by-step. Use analogies where helpful. Calibrate to an intermediate Python/Bash developer. Prioritize understanding over handing off a copy-paste solution.
 
-4. **`MVP:` / `PROTOTYPE:` LEAN-BUT-SAFE BUILDER:** Build the leanest version that still clears the security floor. Apply the **Tier 0/1 baseline** from *Project Phase & Rigor Ladder* — deliver working code fast and cheap, and *defer* the heavy commercial gates (full RLS test matrix, mutation/property/load tiers, DR drills, formal threat models, coverage gates) — but list each deferred gate as an explicit `TODO` with the promotion trigger that should re-enable it. Never relax the floor: no hardcoded secrets, input validation at boundaries, an isolated dev environment, and authentication are non-negotiable at every tier. **Cheap ≠ insecure.**
+4. **`MVP:` / `PROTOTYPE:` LEAN-BUT-SAFE BUILDER:** Build the leanest version that still clears the security floor. Apply the **Tier 0/1 baseline** from *Project Phase & Rigor Ladder* — deliver working code fast and cheap, and *defer* the heavy commercial gates (full RLS test matrix, mutation/property/load tiers, DR drills, formal threat models, coverage gates) — but list each deferred gate as an explicit `TODO` with the promotion trigger that should re-enable it. Never relax the floor: no hardcoded secrets, input validation at boundaries, an isolated dev environment, and authentication are non-negotiable at every tier. **Cheap ≠ insecure.** (`MVP:`/`PROTOTYPE:` name the build *approach*; the rigor *phase* still comes from the ladder — a true throwaway is Tier 0, anything with real users is Tier 1.)
 
 5. **`DEBUG:` SYSTEMATIC DEBUGGER:** A bug is on the table. Do not guess-and-check. Run the method — reproduce on demand, form one falsifiable hypothesis, isolate by bisecting the search space, then fix the **root cause, not the symptom** — and prove it with a regression test seen to fail red first. **The cardinal rule: don't change code until you can explain the bug.** **Read `references/debugging.md`.**
 
@@ -366,7 +367,7 @@ The moment a second writer — agent or human — is in the tree, the solo-speed
 | **Website** | https://briangreenberg.net |
 | **License** | Apache-2.0 |
 | **Created** | 2026-05-18 |
-| **Last updated** | 2026-06-30 |
+| **Last updated** | 2026-07-01 |
 | **Version** | 1.7.1 | <!-- x-release-please-version -->
 
 ### Changelog

--- a/scripts/audit.sh
+++ b/scripts/audit.sh
@@ -25,7 +25,7 @@ ROOT="${1:-.}"
 cd "$ROOT"
 
 if ! command -v pip-audit >/dev/null 2>&1; then
-  echo "audit.sh: pip-audit not found. Install it (e.g. 'pipx install pip-audit') and re-run." >&2
+  echo "audit.sh: pip-audit not found. Install it (e.g. 'pipx install pip-audit' or 'python3 -m pip install pip-audit') and re-run." >&2
   exit 127
 fi
 


### PR DESCRIPTION
## What changed
Seven small, independent doc/polish fixes — Phase 0 of the world-class improvement plan (full audit ran 2026-07-01):

1. **PR template** (`.github/pull_request_template.md`): dropped the stale *"this repo's changelog lives in `SKILL.md`, not a separate `CHANGELOG.md`"* instruction — false since #14 migrated the changelog to release-please. Now points contributors at the Conventional-Commit → release-please flow.
2. **README modes section**: added the `AUDIT:` mode to the modes flowchart **and** the table — it had been missing since v1.2.0 introduced the mode (the skill's own same-commit docs rule, applied to itself).
3. **README architecture diagram**: dropped the hardcoded "27 regression scenarios" count (suite is at 31; a hardcoded count is a static claim that drifts — the honest-badge doctrine applied to prose).
4. **SKILL.md description**: trimmed 1,002 → **956 chars** (limit 1,024) for future edit headroom. No trigger keywords or mode names removed — only redundancy ("secrets in a manager"→"secrets", "+"-separators→"/", "(SBOM/SLSA)" parenthetical, "per-toolchain").
5. **SKILL.md frontmatter**: mirrored `license: Apache-2.0` into the YAML for machine-readability (Agent Skills spec optional field; the human metadata table is unchanged; the release-please version anchor is untouched).
6. **SKILL.md `MVP:` mode**: one clarifying sentence distinguishing the build *approach* (`MVP:`/`PROTOTYPE:`) from the rigor-ladder *phase* (Tier 0/1) — they shared names but not meanings.
7. **scripts/audit.sh**: the pip-audit install hint no longer assumes pipx (adds the `python3 -m pip install` fallback).

## Why it changed
A 7-agent audit of the skill vs Anthropic + industry best practices (2026-07-01) rated it top-decile but flagged these staleness/polish items. Phase 0 = the no-dependency housekeeping tranche; the eval runner (Phase 1) and SKILL.md token-mass reduction (Phase 2) follow separately.

## Testing
- `bash scripts/leakage-guard.sh` → PASS (local)
- `shellcheck scripts/*.sh` → clean (local)
- `bash scripts/render-diagrams.sh README.md` → all 3 Mermaid blocks render cleanly (digest-pinned mmdc container, local)
- Frontmatter re-validated with Ruby Psych (**strict** YAML — the v1.7.1 regression parser): keys `name`/`description`/`license`, description 956 chars
- No discipline added or changed → no new eval scenario required

---
- [x] Branch is rebased on the latest `main`; PR title is a Conventional Commit.
- [x] Small and single-purpose (one change per PR).
- [x] Docs updated in **this** PR.
- [x] `leakage-guard` and `render-diagrams` pass locally.
- [x] No host/employer/personal identifiers added.
- [x] No discipline changed → no eval scenario needed.
- [x] Self-reviewed the diff (correctness, scope, security).

**Claude review (recorded per house policy):** reviewed the full diff line-by-line — all seven changes are doc/message-only, no behavior or discipline change; the description trim preserves every mode trigger and activation keyword; the frontmatter stays Psych-strict-valid; the AUDIT: table row matches the SKILL.md mode definition (report-first, file:line evidence, fixes only after review). **Verdict: SHIP.**