### PR TITLE
feat(evals): add a runner that executes the regression suite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ __pycache__/
 
 # Mermaid render-check scratch output (from scripts/render-diagrams.sh)
 *.svg
+
+# Eval-run output (from scripts/run-evals.py) — curate a keeper into evals/baselines/
+evals/results/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # senior-engineering-partner
 
-Last updated: 2026-07-01 05:17 PM CDT
+Last updated: 2026-07-01 05:56 PM CDT
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/bjgreenberg/senior-engineering-partner?sort=semver&label=release)](https://github.com/bjgreenberg/senior-engineering-partner/releases)
@@ -83,7 +83,7 @@ flowchart TD
     U["/senior-engineering-partner"] --> C
     C["SKILL.md — universal core<br/>modes · epistemic discipline · engineering workflow · rigor ladder<br/>security floor · coding standards · toolchain triggers"]
     C -->|"progressive disclosure: read a reference only when relevant"| R[(references/)]
-    C -.->|"shipped helpers"| K["scripts/ (audit · render-diagrams · self-review)<br/>evals/ (regression scenarios)"]
+    C -.->|"shipped helpers"| K["scripts/ (audit · render-diagrams · run-evals · self-review)<br/>evals/ (regression scenarios)"]
     R --> P["Environment profile<br/>my-environment.md (swap to re-home the skill)"]
     R --> W["Engineering process (4)<br/>engineering-workflow · debugging · audit-report-format · standards-authoring"]
     R --> S["Security, privacy and compliance (6)"]
@@ -208,12 +208,16 @@ support directories:
 
 - **`scripts/`** — the utility scripts the disciplines reference, shipped so they're
   *executed*, not regenerated: `audit.sh` (manifest-level dependency-audit gate),
-  `render-diagrams.sh` (the `docs-render` Mermaid render-check), and `self-review.md` (the
-  verify-before-done checklist). Pin `render-diagrams.sh`'s `MMDC_IMAGE` to a digest before
-  relying on it.
+  `render-diagrams.sh` (the `docs-render` Mermaid render-check), `run-evals.py` (the
+  eval-suite runner — below), and `self-review.md` (the verify-before-done checklist).
+  Pin `render-diagrams.sh`'s `MMDC_IMAGE` to a digest before relying on it.
 - **`evals/`** — a regression suite. Each `scenarios/*.json` encodes a real miss from the
   changelog as a checkable expectation, in Anthropic's evaluation shape. `evals/README.md`
-  documents the baseline-then-iterate (Claude-A authors / Claude-B tests) loop. **Add or
+  documents the baseline-then-iterate (Claude-A authors / Claude-B tests) loop, and
+  **`scripts/run-evals.py` executes the suite**: it runs each `query` headlessly through the
+  `claude` CLI (with the skill injected, or bare for a baseline), LLM-judges the response
+  against `expected_behavior`/`anti_behavior`, and writes per-scenario verdicts + a summary
+  (see *How to run* in `evals/README.md`). **Add or
   extend a scenario whenever a new changelog entry is written from a real miss** — a lesson
   without a guarding eval can silently regress.
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,6 +1,6 @@
 # Evals for senior-engineering-partner
 
-Last updated: 2026-06-29 07:21 PM CDT
+Last updated: 2026-07-01 05:27 PM CDT
 
 A regression suite for the skill itself. Each scenario encodes a **real miss** the skill exists to
 prevent — most are drawn straight from the SKILL.md changelog — so the suite is the executable form of
@@ -40,22 +40,47 @@ origin.
 > (e.g. `v4.0`, `v5.4`) that predate the public `v1.0.0` release and intentionally do **not** appear in
 > the SKILL.md changelog — treat them as provenance notes, not resolvable versions.
 
-## How to run (no built-in runner exists)
+## How to run
 
-There is no first-party eval runner today, so run them as a structured manual/LLM-judge loop:
+**`scripts/run-evals.py` executes the suite.** It needs only the `claude` CLI on PATH
+(authenticated — no API key, no third-party deps): each scenario's `query` runs headlessly
+(`claude -p`), an LLM judge grades the response against every `expected_behavior` and
+`anti_behavior` item, and the overall pass/partial/fail verdict is computed
+**deterministically** from the per-item judgments (any `anti_behavior` violation fails the
+scenario; the judge grades items, it does not decide verdicts).
 
-1. **Baseline first.** Run each `query` against a fresh Claude **without** the skill. Record what it misses —
-   that gap is what the skill must close. (Anthropic: measure baseline before writing/justifying content.)
-2. **With the skill.** Run the same `query` with the skill loaded. Check the response against every
-   `expected_behavior` and confirm no `anti_behavior` appears. Score pass/partial/fail.
-3. **Iterate (Claude-A / Claude-B).** When a scenario fails or a real new miss appears: bring the specifics
+```bash
+# One scenario, quick check
+scripts/run-evals.py --filter spec-first-gate
+
+# Full baseline sweep (bare model, no skill) — record what the skill must close
+scripts/run-evals.py --mode baseline --model opus
+
+# Full with-skill sweep
+scripts/run-evals.py --model opus --judge-model opus
+```
+
+Two run modes, both deterministic about activation (the `Skill` tool is disallowed in every
+run, so a user-level install can't auto-activate and contaminate either mode):
+
+- **`--mode with-skill`** (default) injects the `SKILL.md` body via `--append-system-prompt`,
+  with the skill's base directory pinned so read-on-demand references still resolve.
+- **`--mode baseline`** runs the bare model. The baseline-vs-with-skill gap is what the skill
+  must close (Anthropic: measure the baseline before writing/justifying content).
+
+Results land in `evals/results/<UTC-stamp>-<mode>-<model>/` (git-ignored): one JSON per
+scenario plus `summary.md`/`summary.json`. Curate a run worth keeping (e.g. the pre-edit
+baseline before a large `SKILL.md` restructuring) into `evals/baselines/`. Exit code is `0`
+only when every scenario passes, so the runner can gate.
+
+The loop around the runner is unchanged:
+
+1. **Baseline first**, then **with the skill** — the gap is the skill's measured value.
+2. **Iterate (Claude-A / Claude-B).** When a scenario fails or a real new miss appears: bring the specifics
    back to the skill (Claude-A), strengthen the relevant rule/reference, add or sharpen the scenario, re-run.
    This is the observe→refine→test loop from Anthropic's best-practices guide.
-4. **Test across models** you actually use (Opus / Sonnet / Haiku) — a rule that's obvious to Opus may need
-   to be more prominent for a smaller model.
-
-A thin scorer (feed `query` + response + `expected_behavior` to an LLM judge returning pass/fail+reason) is a
-reasonable future addition; keep the JSON shape stable so it stays machine-runnable.
+3. **Test across models** you actually use (`--model opus|sonnet|haiku`) — a rule that's obvious to Opus may
+   need to be more prominent for a smaller model, and the per-model summaries make that visible.
 
 ## Maintenance
 

--- a/scripts/run-evals.py
+++ b/scripts/run-evals.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python3
+"""run-evals.py — execute the evals/scenarios/*.json regression suite against a live model.
+
+Each scenario's ``query`` is run headlessly through the ``claude`` CLI (``claude -p``),
+then an LLM judge grades the response against the scenario's ``expected_behavior`` and
+``anti_behavior`` lists. The overall verdict is computed deterministically in Python from
+the per-item judgments (the judge grades items; it does not decide the verdict).
+
+Two run modes:
+  --mode with-skill   (default) inject the SKILL.md body via --append-system-prompt, with a
+                      preamble pinning the skill's base directory so read-on-demand
+                      references resolve. Explicit injection — not auto-activation — so the
+                      suite tests the skill's *content* deterministically.
+  --mode baseline     run the bare model (no injection). The Skill tool is disallowed in
+                      BOTH modes so a user-level skill install cannot auto-activate and
+                      contaminate either run.
+
+Requires: the ``claude`` CLI on PATH, authenticated. No API key and no third-party deps
+(stdlib only) — the runner rides the existing CLI auth.
+
+Usage examples:
+  scripts/run-evals.py --filter spec-first-gate            # one scenario, quick check
+  scripts/run-evals.py --mode baseline --model opus        # full baseline sweep
+  scripts/run-evals.py --model opus --judge-model opus     # full with-skill sweep
+
+Results land under evals/results/<UTC-stamp>-<mode>-<model>/ (git-ignored): one JSON per
+scenario plus summary.md / summary.json. Curate a run worth keeping into evals/baselines/.
+"""
+
+from __future__ import annotations
+
+import argparse
+import concurrent.futures
+import datetime
+import json
+import logging
+import re
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any, TypedDict
+
+log = logging.getLogger("run-evals")
+
+SKILL_DIR = Path(__file__).resolve().parent.parent
+SCENARIOS_DIR = SKILL_DIR / "evals" / "scenarios"
+RESULTS_DIR = SKILL_DIR / "evals" / "results"
+
+
+class Scenario(TypedDict, total=False):
+    """The scenario shape documented in evals/README.md."""
+
+    skills: list[str]
+    query: str
+    files: list[str]
+    expected_behavior: list[str]
+    anti_behavior: list[str]
+    source: str
+
+
+class ItemJudgment(TypedDict, total=False):
+    """One judged expected/anti behavior."""
+
+    behavior: str
+    verdict: str  # "pass" | "fail" | "unclear" (expected) / "violated" | "clean" (anti)
+    evidence: str
+
+
+class ScenarioResult(TypedDict, total=False):
+    """Everything recorded for one scenario run."""
+
+    scenario: str
+    mode: str
+    model: str
+    judge_model: str
+    status: str  # "pass" | "partial" | "fail" | "error"
+    expected: list[ItemJudgment]
+    anti: list[ItemJudgment]
+    judge_reason: str
+    response: str
+    duration_s: float
+    cost_usd: float | None
+    error: str
+
+
+def build_skill_system_prompt() -> str:
+    """SKILL.md body (frontmatter stripped) plus a base-dir preamble for the references."""
+    text = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+    match = re.match(r"^---\n.*?\n---\n", text, re.DOTALL)
+    body = text[match.end() :] if match else text
+    preamble = (
+        f"The following skill is ACTIVE for this session. Its base directory is "
+        f"{SKILL_DIR} — when the skill says to read `references/<name>.md`, read "
+        f"{SKILL_DIR}/references/<name>.md.\n\n"
+    )
+    return preamble + body
+
+
+def run_claude(
+    prompt: str,
+    model: str,
+    timeout: int,
+    cwd: Path,
+    system_prompt: str | None = None,
+) -> tuple[str, float | None]:
+    """One headless claude run; returns (response_text, cost_usd). Raises on failure."""
+    cmd = [
+        "claude",
+        "-p",
+        prompt,
+        "--model",
+        model,
+        "--output-format",
+        "json",
+        # Block skill loading in every run: with-skill injects the body itself, and the
+        # baseline must not let a user-level install auto-activate.
+        "--disallowedTools",
+        "Skill",
+    ]
+    if system_prompt is not None:
+        cmd += ["--append-system-prompt", system_prompt]
+    proc = subprocess.run(
+        cmd, capture_output=True, text=True, timeout=timeout, cwd=cwd, check=False
+    )
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"claude exited {proc.returncode}: {proc.stderr.strip()[:500]}"
+        )
+    wrapper: dict[str, Any] = json.loads(proc.stdout)
+    if wrapper.get("subtype") != "success":
+        raise RuntimeError(f"claude result subtype={wrapper.get('subtype')}")
+    return str(wrapper.get("result", "")), wrapper.get("total_cost_usd")
+
+
+JUDGE_INSTRUCTIONS = """You are grading an AI assistant's response against a checklist. Be strict and literal:
+grade only what the response actually does, not what it gestures at.
+
+Return ONLY a JSON object (no markdown fence, no prose) with this exact shape:
+{
+  "expected": [{"behavior": "<verbatim item>", "verdict": "pass|fail|unclear", "evidence": "<short quote or note>"}, ...],
+  "anti": [{"behavior": "<verbatim item>", "verdict": "violated|clean", "evidence": "<short quote or note>"}, ...],
+  "reason": "<one-sentence overall summary>"
+}
+Include every expected_behavior and every anti_behavior item exactly once, in order."""
+
+
+def judge_response(
+    scenario: Scenario, response: str, judge_model: str, timeout: int, cwd: Path
+) -> dict[str, Any]:
+    """LLM-judge one response; returns the parsed judgment JSON."""
+    prompt = (
+        f"{JUDGE_INSTRUCTIONS}\n\n"
+        f"## The user's query\n{scenario['query']}\n\n"
+        f"## expected_behavior checklist\n{json.dumps(scenario.get('expected_behavior', []), indent=1)}\n\n"
+        f"## anti_behavior checklist\n{json.dumps(scenario.get('anti_behavior', []), indent=1)}\n\n"
+        f"## The assistant's response to grade\n<response>\n{response}\n</response>"
+    )
+    raw, _cost = run_claude(prompt, judge_model, timeout, cwd)
+    # Defensive extraction: the judge is told "JSON only," but don't trust it blindly.
+    match = re.search(r"\{.*\}", raw, re.DOTALL)
+    if not match:
+        raise RuntimeError(f"judge returned no JSON object: {raw[:300]}")
+    parsed: dict[str, Any] = json.loads(match.group(0))
+    return parsed
+
+
+def overall_status(expected: list[ItemJudgment], anti: list[ItemJudgment]) -> str:
+    """Deterministic verdict: any anti violation fails; all expected passing passes."""
+    if any(item.get("verdict") == "violated" for item in anti):
+        return "fail"
+    verdicts = [item.get("verdict") for item in expected]
+    if all(v == "pass" for v in verdicts):
+        return "pass"
+    if all(v == "fail" for v in verdicts):
+        return "fail"
+    return "partial"
+
+
+def run_scenario(
+    path: Path, mode: str, model: str, judge_model: str, timeout: int, system_prompt: str | None
+) -> ScenarioResult:
+    """Execute + judge one scenario file; never raises (errors land in the result)."""
+    name = path.stem
+    scenario: Scenario = json.loads(path.read_text(encoding="utf-8"))
+    started = datetime.datetime.now(datetime.timezone.utc)
+    result: ScenarioResult = {
+        "scenario": name,
+        "mode": mode,
+        "model": model,
+        "judge_model": judge_model,
+        "status": "error",
+    }
+    try:
+        if scenario.get("files"):
+            # No scenario ships files today; fail loudly rather than half-support it.
+            raise RuntimeError("scenario declares 'files' — materialization not implemented")
+        with tempfile.TemporaryDirectory(prefix=f"eval-{name}-") as tmp:
+            workdir = Path(tmp)
+            response, cost = run_claude(
+                scenario["query"], model, timeout, workdir, system_prompt
+            )
+            judgment = judge_response(scenario, response, judge_model, timeout, workdir)
+        expected = list(judgment.get("expected", []))
+        anti = list(judgment.get("anti", []))
+        result.update(
+            status=overall_status(expected, anti),
+            expected=expected,
+            anti=anti,
+            judge_reason=str(judgment.get("reason", "")),
+            response=response,
+            cost_usd=cost,
+        )
+    except (RuntimeError, subprocess.TimeoutExpired, json.JSONDecodeError, OSError) as exc:
+        result["error"] = f"{type(exc).__name__}: {exc}"
+        log.error("[%s] %s", name, result["error"])
+    result["duration_s"] = round(
+        (datetime.datetime.now(datetime.timezone.utc) - started).total_seconds(), 1
+    )
+    log.info("[%s] %s (%.0fs)", name, result["status"], result["duration_s"])
+    return result
+
+
+def write_summary(out_dir: Path, results: list[ScenarioResult]) -> str:
+    """Write summary.json + summary.md; returns the one-line tally."""
+    tally = {s: sum(1 for r in results if r["status"] == s) for s in ("pass", "partial", "fail", "error")}
+    line = " · ".join(f"{k}: {v}" for k, v in tally.items())
+    (out_dir / "summary.json").write_text(
+        json.dumps({"tally": tally, "results": results}, indent=1), encoding="utf-8"
+    )
+    rows = "\n".join(
+        f"| {r['scenario']} | {r['status']} | {r.get('judge_reason') or r.get('error', '')} |"
+        for r in sorted(results, key=lambda r: r["scenario"])
+    )
+    (out_dir / "summary.md").write_text(
+        f"# Eval run — {out_dir.name}\n\n**{line}**\n\n"
+        f"| Scenario | Status | Reason |\n|---|---|---|\n{rows}\n",
+        encoding="utf-8",
+    )
+    return line
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--mode", choices=["with-skill", "baseline"], default="with-skill")
+    parser.add_argument("--model", default="opus", help="model for the scenario runs")
+    parser.add_argument("--judge-model", default="opus", help="model for the judge runs")
+    parser.add_argument("--filter", default="", help="substring filter on scenario filenames")
+    parser.add_argument("--jobs", type=int, default=2, help="concurrent scenarios")
+    parser.add_argument("--timeout", type=int, default=600, help="seconds per claude run")
+    parser.add_argument("--out", default="", help="output dir (default: evals/results/<stamp>)")
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s", stream=sys.stderr)
+
+    paths = sorted(p for p in SCENARIOS_DIR.glob("*.json") if args.filter in p.name)
+    if not paths:
+        log.error("no scenarios match filter %r under %s", args.filter, SCENARIOS_DIR)
+        return 2
+    stamp = datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    out_dir = Path(args.out) if args.out else RESULTS_DIR / f"{stamp}-{args.mode}-{args.model}"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    system_prompt = build_skill_system_prompt() if args.mode == "with-skill" else None
+    log.info("%d scenario(s) → %s (mode=%s model=%s judge=%s jobs=%d)",
+             len(paths), out_dir, args.mode, args.model, args.judge_model, args.jobs)
+
+    results: list[ScenarioResult] = []
+    with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
+        futures = {
+            pool.submit(run_scenario, p, args.mode, args.model, args.judge_model,
+                        args.timeout, system_prompt): p
+            for p in paths
+        }
+        for future in concurrent.futures.as_completed(futures):
+            result = future.result()
+            results.append(result)
+            # Checkpoint per scenario so an interrupted sweep loses nothing.
+            (out_dir / f"{result['scenario']}.json").write_text(
+                json.dumps(result, indent=1), encoding="utf-8"
+            )
+
+    line = write_summary(out_dir, results)
+    log.info("done: %s", line)
+    print(f"{line}\nresults: {out_dir}")
+    return 0 if all(r["status"] == "pass" for r in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## What changed
**`scripts/run-evals.py`** — the eval suite's first executable runner (Phase 1 of the world-class plan, and the audit's #2 structural finding: *31 regression guards that never run*).

- Runs every `evals/scenarios/*.json` `query` headlessly through the **`claude` CLI** (`claude -p --output-format json`) — no API key, no third-party deps (stdlib-only Python, full type hints + TypedDicts).
- **LLM-judges** each response against every `expected_behavior` / `anti_behavior` item, then computes the overall pass/partial/fail verdict **deterministically in Python** (any `anti_behavior` violation → fail; all expected pass + no violations → pass). The judge grades items; it does not decide verdicts — the deterministic-first rule applied to the harness itself.
- **Two activation-deterministic modes** (the `Skill` tool is disallowed in every run so a user-level install can't auto-activate and contaminate either): `--mode with-skill` injects the SKILL.md body via `--append-system-prompt` with the skill's base dir pinned (read-on-demand references still resolve); `--mode baseline` runs the bare model to measure the gap the skill must close.
- `--filter`, `--model`/`--judge-model` (per-model matrices per the evals README), `--jobs`, `--timeout`; per-scenario JSON **checkpoints** as each finishes + `summary.md`/`summary.json`; git-ignored `evals/results/`; exit 0 only on all-pass so it can gate.
- Docs in the same commit: `evals/README.md` *How to run* rewritten (it previously — honestly — said no runner existed), README `scripts/`+`evals/` sections + architecture diagram, `.gitignore`.

## Why it changed
The 2026-07-01 audit's load-bearing sequencing decision: the eval runner must exist **before** the Phase-2 SKILL.md token-mass reduction, so that restructuring is validated against a recorded baseline instead of hoped about. A scenario declaring `files` fails loudly (none do today) rather than half-supporting it.

## Testing
- Smoke run (plumbing): `scripts/run-evals.py --filter spec-first-gate --model haiku --judge-model haiku` → completed end-to-end in 46s; verdict **partial** with a specific, correct-looking judgment (haiku+skill asked scope questions but missed the Tier-2 idempotency/threat-model framing) — exactly the per-model signal the evals README wants.
- `python3 -m py_compile` clean; `bash scripts/leakage-guard.sh` PASS; `shellcheck scripts/*.sh` clean (runner is Python — a python lint/typecheck CI gate is **deferred-with-trigger**: add when a second Python file lands or the runner starts gating CI); `render-diagrams.sh README.md` → all 3 blocks render.
- Full Opus baseline sweep is the immediate follow-up (results to `evals/baselines/`), then CI cadence is a maintainer cost decision (scheduled vs per-PR).

---
- [x] Branch is rebased on the latest `main`; PR title is a Conventional Commit. *(Note: will need a trivial rebase if #46 merges first — both touch the README stamp + diagram line.)*
- [x] Small and single-purpose.
- [x] Docs updated in **this** PR (evals/README, README, .gitignore).
- [x] `leakage-guard` + `render-diagrams` pass locally.
- [x] No host/employer/personal identifiers added.
- [x] No *discipline* added or changed → no new scenario required (this executes the existing ones).
- [x] Self-reviewed the diff.

**Claude review (recorded per house policy):** reviewed the runner line-by-line — subprocess calls use argument vectors (no shell interpolation), scenario files are read from the repo only, temp dirs isolate each run, timeouts bound every subprocess, errors are captured per-scenario instead of aborting the sweep, and the verdict logic is deterministic and covered by the smoke run. Flags verified against `claude` 2.1.197 `--help` (notably: no `--max-turns` in this version — timeout used instead). **Verdict: SHIP.**