### PR TITLE
fix(privacy): scrub a domain fingerprint from the PQC eval scenario; warn on Tier-2-less guard runs

### DIFF
--- a/evals/scenarios/crypto-agility-pqc-hndl.json
+++ b/evals/scenarios/crypto-agility-pqc-hndl.json
@@ -1,6 +1,6 @@
 {
   "skills": ["senior-engineering-partner"],
-  "query": "REVIEW: Our forensic evidence platform stores encrypted client evidence under a 10-year retention class. Transport is TLS 1.3, storage is AES-256 via GCS defaults, commits are signed with ed25519. A customer's security questionnaire asks about our post-quantum readiness, and I plan to answer 'not applicable — we already use strong modern cryptography.' Review that answer before I send it.",
+  "query": "REVIEW: Our e-discovery platform stores encrypted client evidence under a 10-year retention class. Transport is TLS 1.3, storage is AES-256 via GCS defaults, commits are signed with ed25519. A customer's security questionnaire asks about our post-quantum readiness, and I plan to answer 'not applicable — we already use strong modern cryptography.' Review that answer before I send it.",
   "files": [],
   "expected_behavior": [
     "Pushes back on 'not applicable': names harvest-now-decrypt-later (HNDL) — transport traffic or ciphertext recorded today becomes decryptable when a cryptanalytically-relevant quantum computer arrives, so a 10-year-retention confidential class must keep its secrets through the classical-to-post-quantum transition",

--- a/scripts/leakage-guard.sh
+++ b/scripts/leakage-guard.sh
@@ -43,6 +43,10 @@ if [[ -f "$local_list" ]]; then
     frag="${frag%"${frag##*[![:space:]]}"}"              # rtrim
     denylist+="|${frag}"
   done < "$local_list"
+else
+  # A missing local list silently downgrades this run to Tier-1 only — say so loudly, so a
+  # worktree/fresh-clone run is never mistaken for the full pre-PR gate (CONTRIBUTING.md).
+  echo "WARN: $local_list not found — Tier 2 (private identifiers) NOT checked; this run covers Tier 1 only." >&2
 fi
 
 # Files to scan: tracked Markdown/JSON/shell, excluding this script and the private profile.


### PR DESCRIPTION
## What changed
- `evals/scenarios/crypto-agility-pqc-hndl.json`: the scenario's product framing is re-domained ("e-discovery platform") — the prior phrasing matched an entry on the private Tier-2 leakage denylist. Judge semantics unchanged (10-year retention class, evidence re-verified years later).
- `scripts/leakage-guard.sh`: **warns loudly when `references/leakage-denylist.local` is absent** — previously Tier 2 silently no-opped, so a run from a git worktree or fresh clone (which never has the gitignored file) could read as a full pre-PR pass while checking Tier 1 only.

## Why
The root cause is the silent downgrade, not the wording: the scenario was authored in a git worktree, the local guard run passed there (Tier-1-only, unannounced), and CI can only ever check Tier 1 by design. The next full local run on the primary clone caught it. Fix-at-source: scrub the fingerprint AND make the downgrade visible so this class can't false-green again.

## Adversarial review (recorded)
Proportionate self-review for a 2-file, 5-line fix: scenario JSON validates and its expected/anti items are untouched; shellcheck clean; full Tier-1+2 guard PASS post-fix; the warning goes to stderr and does not change the exit code (CI, which legitimately has no local list, stays green).

## Testing instructions
- `python3 -c 'import json; json.load(open("evals/scenarios/crypto-agility-pqc-hndl.json"))'"'"'` → valid
- `shellcheck scripts/leakage-guard.sh` → clean
- `./scripts/leakage-guard.sh` on a clone **with** the local list → PASS, no warning; in a worktree **without** it → PASS with the Tier-1-only WARN on stderr