### PR TITLE
docs: README stamp + PQC coverage mentions; record the title-only squash setting

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -54,7 +54,7 @@ bumps the `Version` in [`SKILL.md`](SKILL.md) and prepends the new section to
    *(Learned the hard way: the 1.5.0 release PR stayed `autorelease: pending` and silently blocked the
    1.6.0 release PR across six green workflow runs until it was relabeled.)*
 
-### Gotcha: a squash body can make release-please skip the commit entirely
+### Gotcha (historical here since the title-only flip; live wherever squash includes the PR body): a squash body can make release-please skip the commit entirely
 
 **Since 2026-07-02 this repo squashes with "Default to pull request title" only** (API:
 `PR_TITLE` + `BLANK`) — flipped precisely to kill this failure class; the enriched CHANGELOG,

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -56,9 +56,12 @@ bumps the `Version` in [`SKILL.md`](SKILL.md) and prepends the new section to
 
 ### Gotcha: a squash body can make release-please skip the commit entirely
 
-This repo's squash-merge setting is **"Default to pull request title and description"** (the API
-calls it `PR_TITLE` + `PR_BODY`), so the whole PR description becomes the *commit message body* —
-and release-please runs the *conventional-commits parser over that body*. A body
+**Since 2026-07-02 this repo squashes with "Default to pull request title" only** (API:
+`PR_TITLE` + `BLANK`) — flipped precisely to kill this failure class; the enriched CHANGELOG,
+not the commit body, carries each release's narrative. The gotcha below still matters if the
+setting is ever reverted, and for any repo squashing with "title and description" (`PR_BODY`):
+the whole PR description becomes the *commit message body*, and release-please runs the
+*conventional-commits parser over that body*. A body
 line that (after GitHub's ~72-column hard-wrap) **begins with a `token(`-shaped fragment** — e.g.
 a wrapped code snippet starting a line with `json.load(open(` — is read as a malformed footer and
 the parser rejects the WHOLE commit: the run logs `commit could not be parsed … unexpected token '('`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # senior-engineering-partner
 
-Last updated: 2026-07-01 05:56 PM CDT
+Last updated: 2026-07-02 01:23 PM CDT
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/bjgreenberg/senior-engineering-partner?sort=semver&label=release)](https://github.com/bjgreenberg/senior-engineering-partner/releases)
@@ -61,7 +61,7 @@ carries standards for:
 - **Cloud & infra:** GCP / Cloud Run · Docker · Kubernetes · Terraform (IaC)
 - **Data:** Postgres / Supabase (RLS) · BigQuery · SQLite · caching
 - **App layer:** FastAPI / Python web APIs · front-end & browser security · responsive, accessible (WCAG 2.2 AA) UI · LLM-app engineering (workflow/agent-loop patterns · stopping criteria · evals)
-- **Security & standards:** the security floor (secrets · injection · input validation · isolation · least privilege) · NIST CSF 2.0 + SSDF · OWASP Top 10 / **API Top 10** / **LLM Top 10** · STRIDE · SOC 2 · Well-Architected · PCI-DSS scope
+- **Security & standards:** the security floor (secrets · injection · input validation · isolation · least privilege) · NIST CSF 2.0 + SSDF · OWASP Top 10 / **API Top 10** / **LLM Top 10** · STRIDE · SOC 2 · Well-Architected · PCI-DSS scope · crypto-agility / **post-quantum readiness** (FIPS 203–205, HNDL)
 - **Reliability & ops:** resilience engineering · disaster recovery & business continuity · scalability / system design · observability + incident response (DORA · SLOs)
 - **Platform-specific:** macOS app bundles / TCC · local & agentic AI tooling · diagrams-as-code (Mermaid)
 
@@ -169,7 +169,7 @@ version-specific commands.
 | | `frontend-web-security.md` | Token storage, CSP, output sanitization, security headers |
 | | `secrets-and-key-rotation.md` | Rotation lifecycle, zero-downtime overlap, KMS key-version re-wrap |
 | | `data-protection.md` | GDPR/UK-GDPR/CCPA as code: DSAR, erasure cascade, retention, DPIA |
-| | `compliance.md` | NIST CSF 2.0 + **SSDF (800-218)** / OWASP / SOC 2 / **Well-Architected** as enforceable review checklists |
+| | `compliance.md` | NIST CSF 2.0 + **SSDF (800-218)** / OWASP / SOC 2 / **Well-Architected** as enforceable review checklists, incl. crypto-agility + **post-quantum readiness** (FIPS 203–205, harvest-now-decrypt-later triage) |
 | **Testing & QA** | `testing.md` | The enforced merge-gate taxonomy, tenant-isolation tests, coverage/mutation/load tiers |
 | | `testing-single-file.md` | The `conftest.py` argv-patch pattern for single-file scripts |
 | **Cloud, infra & ops** | `gcp.md` | Cloud Run, GCS, BigQuery, Secret Manager, IAM (no SA keys → Workload Identity) |


### PR DESCRIPTION
## What changed
- README: the `Last updated` stamp is bumped — #55 modified the README without refreshing it (the house same-commit stamp rule; this closes that miss), and the v1.10.0 crypto-agility/post-quantum coverage now appears where the README describes coverage (the *What it governs* security line and the `compliance.md` catalog row — #53 updated SKILL.md but not these).
- MAINTAINERS.md: the release gotcha section now leads with the repo's **new squash setting** — title-only (`PR_TITLE` + `BLANK`), flipped 2026-07-02 to eliminate the parse-failure class — and keeps the PR_BODY gotcha as history/portable guidance.

## Why
Owner review caught the README staleness; the squash-setting flip was owner-approved and its documentation must land with it (the always-document rule).

## Testing instructions
leakage-guard PASS locally (Tier 1+2); docs-only diff, no Mermaid changes.