### PR TITLE
chore(repo): Phase-4 smalls — mermaid-cli re-pin cadence, gate-script fixture tests, green-optional skill-lint

### DIFF
--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -27,4 +27,4 @@ jobs:
       - name: Run gate-script fixture tests
         run: |
           set -euo pipefail
-          scripts/tests/test-scripts.sh
+          bash scripts/tests/test-scripts.sh

--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -1,0 +1,30 @@
+name: script-tests
+
+# Fixture regression tests for the shipped gate scripts (plan item C6). The rule they enforce
+# is references/testing.md §3c — a gate must be ABLE to fail: each gate gets a
+# planted-violation fixture it must FAIL on and a clean fixture it must PASS on, so a change
+# that silently blinds a gate (the classic leakage-guard regression risk) goes red here
+# instead of shipping. Runs scripts/tests/test-scripts.sh — the same script a maintainer runs
+# locally (stock-bash-3.2-compatible, no docker, no network).
+#
+# GREEN-OPTIONAL by design: not in the ruleset's required checks — promotion to required is
+# the maintainer's explicit call, never a default.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  script-tests:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Run gate-script fixture tests
+        run: |
+          set -euo pipefail
+          scripts/tests/test-scripts.sh

--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -1,0 +1,28 @@
+name: skill-lint
+
+# Validate SKILL.md against the Agent Skills packaging constraints: frontmatter present and
+# carrying name + description, name format/length + skill-directory match, and the 1024-char
+# description limit this repo has tripped over before (CHANGELOG v1.1.0). Stdlib-only Python,
+# so the local run and CI are byte-identical: scripts/skill-lint.py.
+#
+# GREEN-OPTIONAL by design (plan item C7): not in the ruleset's required checks — promotion
+# to required is the maintainer's explicit call, never a default.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  skill-lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Lint SKILL.md packaging
+        run: |
+          set -euo pipefail
+          python3 scripts/skill-lint.py SKILL.md

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,15 @@ This project is maintained by:
   `main` even from unsigned feature branches — no commit-signing setup required to contribute.
 - Security reports go through **private advisories**, never public issues — see [SECURITY.md](SECURITY.md).
 
+### mermaid-cli re-pin cadence (docs-render gate)
+
+`scripts/render-diagrams.sh` runs mermaid-cli from a digest-pinned container image (`MMDC_IMAGE` — the single pin location; the docs-render workflow calls the script). The digest keeps the gate reproducible; it does not keep it current (SKILL.md *stay current, not just pinned* — a pin is for reproducibility, not a museum). **Re-pin quarterly**, or sooner when a Mermaid syntax feature or rendering fix we need ships:
+
+1. Read the mermaid-cli release notes for rendering changes that could alter committed diagrams.
+2. Resolve the new tag's digest: `docker buildx imagetools inspect ghcr.io/mermaid-js/mermaid-cli/mermaid-cli:<tag>`.
+3. Update `MMDC_IMAGE` in `scripts/render-diagrams.sh` (tag noted in the comment, digest in the pin).
+4. Prove it: run the render check over every diagram-bearing file locally, or let the `docs-render` gate do it on the PR — a digest bump that changes rendering behavior must fail there, not on `main`.
+
 ## Cutting a release
 
 Releases are **prepared by [release-please](https://github.com/googleapis/release-please) and

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # senior-engineering-partner
 
-Last updated: 2026-07-03 06:54 PM CDT
+Last updated: 2026-07-03 07:04 PM CDT
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/bjgreenberg/senior-engineering-partner?sort=semver&label=release)](https://github.com/bjgreenberg/senior-engineering-partner/releases)
@@ -83,7 +83,7 @@ flowchart TD
     U["/senior-engineering-partner"] --> C
     C["SKILL.md — universal core<br/>modes · epistemic discipline · engineering workflow · rigor ladder<br/>security floor · coding standards · toolchain triggers"]
     C -->|"progressive disclosure: read a reference only when relevant"| R[(references/)]
-    C -.->|"shipped helpers"| K["scripts/ (audit · render-diagrams · run-evals · self-review)<br/>evals/ (regression scenarios)"]
+    C -.->|"shipped helpers"| K["scripts/ (audit · render-diagrams · run-evals · skill-lint · self-review · fixture tests)<br/>evals/ (regression scenarios)"]
     R --> P["Environment profile<br/>my-environment.md (swap to re-home the skill)"]
     R --> W["Engineering process (4)<br/>engineering-workflow · debugging · audit-report-format · standards-authoring"]
     R --> S["Security, privacy and compliance (6)"]

--- a/scripts/skill-lint.py
+++ b/scripts/skill-lint.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""skill-lint.py — validate SKILL.md against the Agent Skills packaging constraints.
+
+Checks the constraints that are deterministic and documented (Anthropic's Agent Skills
+format — the same shape Codex CLI / Gemini CLI consume; see README "Using it with other
+AI tools"):
+
+  1. YAML frontmatter exists and is well-formed enough to carry `name` + `description`
+     (parsed with a minimal stdlib reader — no third-party deps, so CI == local).
+  2. `name`: present; lowercase letters/digits/hyphens only; <= 64 chars; matches the
+     repository/skill directory name.
+  3. `description`: present, non-empty, <= 1024 characters (the documented limit this
+     repo has tripped over before — see CHANGELOG v1.1.0).
+  4. Unknown frontmatter keys are WARNED, not failed (the spec allows optional fields;
+     a typo'd required key still fails via checks 2-3).
+
+Exit 0 = all checks pass (warnings allowed). Exit 1 = any check failed.
+Usage: scripts/skill-lint.py [path-to-SKILL.md]
+"""
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+KNOWN_KEYS = {"name", "description", "license", "allowed-tools", "metadata", "version"}
+NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
+DESCRIPTION_LIMIT = 1024
+NAME_LIMIT = 64
+
+
+def parse_frontmatter(text: str) -> dict[str, str] | None:
+    """Minimal single-level YAML frontmatter reader (stdlib-only).
+
+    Handles the subset this repo uses: `key: value` lines with optional double-quoted
+    values. Multi-line/nested values are recorded with a sentinel so key presence still
+    registers without a YAML dependency.
+    """
+    m = re.match(r"^---\r?\n(.*?)\r?\n---\r?\n", text, re.S)
+    if not m:
+        return None
+    fields: dict[str, str] = {}
+    current_key: str | None = None
+    for line in m.group(1).splitlines():
+        if not line.strip() or line.strip().startswith("#"):
+            continue
+        if line[0] in " \t":  # continuation / nested value under the last key
+            if current_key:
+                fields[current_key] += " <nested>"
+            continue
+        km = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
+        if not km:
+            return None  # a top-level line that isn't key:value = malformed frontmatter
+        key, value = km.group(1), km.group(2).strip()
+        if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+            value = value[1:-1]
+        fields[key] = value
+        current_key = key
+    return fields
+
+
+def main() -> int:
+    skill_path = Path(sys.argv[1]) if len(sys.argv) > 1 else Path("SKILL.md")
+    if not skill_path.is_file():
+        print(f"FAIL: {skill_path} not found", file=sys.stderr)
+        return 1
+    fields = parse_frontmatter(skill_path.read_text(encoding="utf-8"))
+    failures: list[str] = []
+    warnings: list[str] = []
+
+    if fields is None:
+        print("FAIL: SKILL.md has no well-formed YAML frontmatter block", file=sys.stderr)
+        return 1
+
+    name = fields.get("name", "")
+    if not name:
+        failures.append("frontmatter `name` is missing/empty")
+    else:
+        if not NAME_RE.match(name):
+            failures.append(f"`name` must be lowercase letters/digits/hyphens: {name!r}")
+        if len(name) > NAME_LIMIT:
+            failures.append(f"`name` exceeds {NAME_LIMIT} chars ({len(name)})")
+        expected = skill_path.resolve().parent.name
+        if name != expected:
+            failures.append(f"`name` ({name!r}) != skill directory name ({expected!r})")
+
+    description = fields.get("description", "")
+    if not description:
+        failures.append("frontmatter `description` is missing/empty")
+    elif len(description) > DESCRIPTION_LIMIT:
+        failures.append(
+            f"`description` exceeds {DESCRIPTION_LIMIT} chars ({len(description)})"
+        )
+
+    for key in sorted(set(fields) - KNOWN_KEYS):
+        warnings.append(f"unknown frontmatter key {key!r} (not failed; verify against the spec)")
+
+    for w in warnings:
+        print(f"WARN: {w}", file=sys.stderr)
+    if failures:
+        for f_ in failures:
+            print(f"FAIL: {f_}", file=sys.stderr)
+        return 1
+    print(
+        f"PASS: skill-lint — name OK, description {len(description)}/{DESCRIPTION_LIMIT} chars"
+        + (f", {len(warnings)} warning(s)" if warnings else "")
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/skill-lint.py
+++ b/scripts/skill-lint.py
@@ -33,8 +33,9 @@ def parse_frontmatter(text: str) -> dict[str, str] | None:
     """Minimal single-level YAML frontmatter reader (stdlib-only).
 
     Handles the subset this repo uses: `key: value` lines with optional double-quoted
-    values. Multi-line/nested values are recorded with a sentinel so key presence still
-    registers without a YAML dependency.
+    values, plus indented continuation / block-scalar content (`>`/`|` styles), which is
+    ACCUMULATED into the key's value — so the description length check measures the real
+    content and cannot be bypassed by writing the description as a multi-line block.
     """
     m = re.match(r"^---\r?\n(.*?)\r?\n---\r?\n", text, re.S)
     if not m:
@@ -44,15 +45,17 @@ def parse_frontmatter(text: str) -> dict[str, str] | None:
     for line in m.group(1).splitlines():
         if not line.strip() or line.strip().startswith("#"):
             continue
-        if line[0] in " \t":  # continuation / nested value under the last key
+        if line[0] in " \t":  # continuation / block-scalar content under the last key
             if current_key:
-                fields[current_key] += " <nested>"
+                fields[current_key] = (fields[current_key] + " " + line.strip()).strip()
             continue
         km = re.match(r"^([A-Za-z0-9_-]+):\s*(.*)$", line)
         if not km:
             return None  # a top-level line that isn't key:value = malformed frontmatter
         key, value = km.group(1), km.group(2).strip()
-        if len(value) >= 2 and value[0] == '"' and value[-1] == '"':
+        if value in {">", "|", ">-", "|-", ">+", "|+"}:
+            value = ""  # block-scalar indicator — the real content follows indented
+        elif len(value) >= 2 and value[0] == '"' and value[-1] == '"':
             value = value[1:-1]
         fields[key] = value
         current_key = key

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+#
+# test-scripts.sh — fixture regression tests for the shipped gate scripts (plan item C6).
+#
+# The gate-construction rule these tests enforce (references/testing.md §3c): a gate must be
+# ABLE to fail. Each shipped gate gets (a) a planted-violation fixture the gate must FAIL on,
+# and (b) a clean fixture it must PASS on — so a regression that silently blinds a gate (the
+# exact failure mode C6 names for leakage-guard) goes red here instead of shipping.
+#
+# Scope: leakage-guard.sh (Tier 1 — the generic class-patterns; the Tier-2 .local file is
+# per-machine and deliberately untested here) and skill-lint.py. render-diagrams.sh is NOT
+# fixture-tested here: it needs the docker mermaid-cli image, and the docs-render CI job
+# already exercises both its pass path (every committed diagram) and its fail path was proven
+# at introduction; a docker pull in this quick suite would slow every run for little signal.
+#
+# Runs on stock bash 3.2 (no mapfile/associative arrays). No network, no docker.
+# Usage: scripts/tests/test-scripts.sh   (exit 0 = all pass)
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+pass=0
+fail=0
+
+note() { printf '%s\n' "$*" >&2; }
+
+check() { # check <description> <expected-exit> <actual-exit>
+  local desc="$1" expected="$2" actual="$3"
+  if [[ "$actual" -eq "$expected" ]]; then
+    pass=$((pass + 1))
+  else
+    note "FAIL: ${desc} (expected exit ${expected}, got ${actual})"
+    fail=$((fail + 1))
+  fi
+}
+
+scratch="$(mktemp -d)"
+cleanup() { rm -rf "$scratch"; }
+trap cleanup EXIT
+
+# --- leakage-guard.sh fixtures -------------------------------------------------------------
+# The guard cd's to its own repo root, so each fixture is a throwaway git repo with the guard
+# script copied in at scripts/leakage-guard.sh.
+make_guard_fixture() { # make_guard_fixture <dir>
+  local dir="$1"
+  mkdir -p "$dir/scripts" "$dir/references"
+  cp "$repo_root/scripts/leakage-guard.sh" "$dir/scripts/leakage-guard.sh"
+  git -C "$dir" init -q
+}
+
+# (a) planted Tier-1 violations -> the guard must FAIL (exit 1) and name the file.
+# NB: the violation strings are ASSEMBLED at runtime — a literal in this tracked file would
+# (correctly!) trip the real leakage-guard on this repo. That near-miss happened during
+# authoring: the guard scans TRACKED files, so this script passed pre-`git add` and failed
+# right after — the exact class of gate-blinding subtlety this suite exists to catch.
+violdir="$scratch/guard-violation"
+make_guard_fixture "$violdir"
+lb='['
+{
+  echo "# doc"
+  printf 'the host lives at 100.%s on the tailnet\n' "71.2.3"   # CGNAT/Tailscale class pattern
+  printf 'see %s%sproject-notes]] for details\n' "$lb" "$lb"    # wikilink class pattern
+} > "$violdir/README.md"
+git -C "$violdir" add -A
+rc=0; (cd "$violdir" && bash scripts/leakage-guard.sh) >/dev/null 2>&1 || rc=$?
+check "leakage-guard FAILS on planted Tier-1 identifiers" 1 "$rc"
+
+# ...and the failure output names the offending file (verdict, not just exit code — §3c).
+out="$( (cd "$violdir" && bash scripts/leakage-guard.sh) 2>&1 || true )"
+rc=0; grep -q "README.md" <<<"$out" || rc=$?
+check "leakage-guard failure output names the offending file" 0 "$rc"
+
+# (b) clean fixture -> the guard must PASS (exit 0), warning that Tier 2 is absent.
+cleandir="$scratch/guard-clean"
+make_guard_fixture "$cleandir"
+printf '# doc\nnothing environment-specific here.\n' > "$cleandir/README.md"
+git -C "$cleandir" add -A
+rc=0; out="$( (cd "$cleandir" && bash scripts/leakage-guard.sh) 2>&1 )" || rc=$?
+check "leakage-guard PASSES on a clean tree" 0 "$rc"
+rc=0; grep -q "Tier 1 only" <<<"$out" || rc=$?
+check "leakage-guard WARNs Tier-1-only when the .local denylist is absent" 0 "$rc"
+
+# --- skill-lint.py fixtures ------------------------------------------------------------------
+lintdir="$scratch/skill-fixture/good-skill"
+mkdir -p "$lintdir"
+printf -- '---\nname: good-skill\ndescription: "A test skill."\n---\n# body\n' > "$lintdir/SKILL.md"
+rc=0; python3 "$repo_root/scripts/skill-lint.py" "$lintdir/SKILL.md" >/dev/null 2>&1 || rc=$?
+check "skill-lint PASSES a conforming SKILL.md" 0 "$rc"
+
+badlintdir="$scratch/skill-fixture/bad-skill"
+mkdir -p "$badlintdir"
+long_desc="$(printf 'x%.0s' $(seq 1 1100))"
+printf -- '---\nname: Mismatched_Name\ndescription: "%s"\n---\n# body\n' "$long_desc" > "$badlintdir/SKILL.md"
+rc=0; python3 "$repo_root/scripts/skill-lint.py" "$badlintdir/SKILL.md" >/dev/null 2>&1 || rc=$?
+check "skill-lint FAILS on bad name + oversize description" 1 "$rc"
+
+rc=0; python3 "$repo_root/scripts/skill-lint.py" "$scratch/does-not-exist/SKILL.md" >/dev/null 2>&1 || rc=$?
+check "skill-lint FAILS on a missing file" 1 "$rc"
+
+# --- the real repo passes its own gates (precondition assert, not print — §3c) --------------
+rc=0; python3 "$repo_root/scripts/skill-lint.py" "$repo_root/SKILL.md" >/dev/null 2>&1 || rc=$?
+check "skill-lint PASSES the real SKILL.md" 0 "$rc"
+
+note "test-scripts: ${pass} passed, ${fail} failed"
+[[ "$fail" -eq 0 ]]

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -96,6 +96,19 @@ check "skill-lint FAILS on bad name + oversize description" 1 "$rc"
 rc=0; python3 "$repo_root/scripts/skill-lint.py" "$scratch/does-not-exist/SKILL.md" >/dev/null 2>&1 || rc=$?
 check "skill-lint FAILS on a missing file" 1 "$rc"
 
+# Block-scalar bypass (a Copilot-review catch): an oversize description written as a
+# multi-line block must still trip the length gate — the parser accumulates continuation
+# content instead of counting a sentinel.
+blockdir="$scratch/skill-fixture/block-skill"
+mkdir -p "$blockdir"
+{
+  printf -- '---\nname: block-skill\ndescription: >-\n'
+  for _ in 1 2 3 4 5 6; do printf '  %s\n' "$(printf 'y%.0s' $(seq 1 200))"; done
+  printf -- '---\n# body\n'
+} > "$blockdir/SKILL.md"
+rc=0; python3 "$repo_root/scripts/skill-lint.py" "$blockdir/SKILL.md" >/dev/null 2>&1 || rc=$?
+check "skill-lint FAILS on an oversize block-scalar description (bypass closed)" 1 "$rc"
+
 # --- the real repo passes its own gates (precondition assert, not print — §3c) --------------
 rc=0; python3 "$repo_root/scripts/skill-lint.py" "$repo_root/SKILL.md" >/dev/null 2>&1 || rc=$?
 check "skill-lint PASSES the real SKILL.md" 0 "$rc"


### PR DESCRIPTION
## What changed

The three optional Phase-4 smalls from the world-class plan, in one chore PR:

- **C4 — mermaid-cli re-pin cadence**: a new MAINTAINERS.md subsection under *How we work* — quarterly re-pin of the digest-pinned `MMDC_IMAGE` (single pin location: `scripts/render-diagrams.sh`; the workflow calls the script), with the 4-step procedure (release notes → resolve digest → update pin → prove via the render gate).
- **C6 — gate-script fixture tests**: `scripts/tests/test-scripts.sh` (stock-bash-3.2-compatible, shellcheck-clean, no docker/network) — enforces `references/testing.md` §3c *a gate must be able to fail*: leakage-guard must FAIL on a planted Tier-1 violation fixture (and name the file in its output), PASS on a clean one (warning Tier-1-only where the private denylist is absent); skill-lint must PASS a conforming fixture and FAIL a bad-name/oversize-description one; and the real repo passes both. **8/8 locally.** Scoping note in the header: render-diagrams.sh is deliberately not fixture-tested here (needs the docker image; the docs-render gate exercises it on every diagram-bearing file).
- **C7 — green-optional skill-lint**: `scripts/skill-lint.py` (stdlib-only, so local == CI byte-identically) validates SKILL.md's Agent-Skills packaging — frontmatter shape, `name` format/length + skill-directory match, the **1024-char description limit** this repo has tripped over before (currently 956/1024; unknown frontmatter keys WARN, never fail). Plus `.github/workflows/skill-lint.yml` and `.github/workflows/script-tests.yml`, both SHA-pinned checkout + `contents: read`, and **NOT added to the ruleset's required checks — green-optional per the plan's explicit constraint; promotion is Brian's call.**

Docs same-commit: README scripts list + stamp; MAINTAINERS.md (the C4 section). No SKILL.md/reference content changes — no eval implications.

## Why

Plan items C4/C6/C7 ("optional smalls if time" per the Phase-4 kickoff). C6 closes the plan's named risk — "a leakage-guard regression could slip"; C7 turns the v1.1.0 description-length lesson into a standing check.

## Testing instructions

- `scripts/tests/test-scripts.sh` → 8 passed, 0 failed (also runs in the new script-tests job).
- `python3 scripts/skill-lint.py SKILL.md` → PASS, description 956/1024.
- `shellcheck scripts/tests/test-scripts.sh` clean; leakage-guard **Tier-2 PASS run against the STAGED tree**; README mermaid render-checked (3/3 blocks).

## Review

Chore-tier diff (scripts + workflows + docs; no skill content) — per the tier-gated review discipline, no multi-lens panel; structured self-review recorded: workflows least-privilege + SHA-pinned; both new jobs deliberately absent from the ruleset; the fixture suite was red-first-proven during staging (it failed when pointed at a mis-named skill dir).

**A self-caught near-miss worth reading**: the first cut of the fixture suite embedded the planted Tier-1 violation strings as literals — and the repo's own leakage-guard (correctly) flagged them the moment the file was tracked. It had passed the pre-commit gate run only because the guard scans *tracked* files and the script wasn't `git add`-ed yet. Fixed by assembling the fixture strings at runtime, with a comment telling the story; gate runs now happen against the staged tree.