### PR TITLE
docs(policy): skill-lint + script-tests are now required checks

### DIFF
--- a/.github/workflows/script-tests.yml
+++ b/.github/workflows/script-tests.yml
@@ -7,8 +7,8 @@ name: script-tests
 # instead of shipping. Runs scripts/tests/test-scripts.sh — the same script a maintainer runs
 # locally (stock-bash-3.2-compatible, no docker, no network).
 #
-# GREEN-OPTIONAL by design: not in the ruleset's required checks — promotion to required is
-# the maintainer's explicit call, never a default.
+# REQUIRED status check since 2026-07-04 (promoted from green-optional on the maintainer's
+# explicit call — promotion to required is never a default).
 
 on:
   push:

--- a/.github/workflows/skill-lint.yml
+++ b/.github/workflows/skill-lint.yml
@@ -5,8 +5,8 @@ name: skill-lint
 # description limit this repo has tripped over before (CHANGELOG v1.1.0). Stdlib-only Python,
 # so the local run and CI are byte-identical: scripts/skill-lint.py.
 #
-# GREEN-OPTIONAL by design (plan item C7): not in the ruleset's required checks — promotion
-# to required is the maintainer's explicit call, never a default.
+# REQUIRED status check since 2026-07-04 (promoted from green-optional, plan item C7, on the
+# maintainer's explicit call — promotion to required is never a default).
 
 on:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ may not be checkable enough yet.
   every review thread addressed or resolved. We don't merge on green CI alone: green proves the
   *gates* passed, not that the change is correct, in-scope, and free of a subtle regression a check
   didn't cover.
-- The repo's **required checks** (`docs-render`, `leakage-guard`, `shellcheck`) must pass.
+- The repo's **required checks** (`docs-render`, `leakage-guard`, `shellcheck`, `skill-lint`, `script-tests`) must pass.
 - Merges are **squash-only** — rebase-merge (it rewrites your commits *unsigned*) and merge-commit
   are both disabled — and the branch is auto-deleted on merge. GitHub signs the squash commit, so
   your contribution lands **Verified** on `main` even if your own commits weren't signed; you don't

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,7 @@ This project is maintained by:
 ## How we work
 
 - Every change lands via a pull request with the required checks green (`docs-render`, `leakage-guard`,
-  `shellcheck`) and a maintainer review — see [CONTRIBUTING.md](CONTRIBUTING.md).
+  `shellcheck`, `skill-lint`, `script-tests`) and a maintainer review — see [CONTRIBUTING.md](CONTRIBUTING.md).
 - The branch ruleset requires **1 approving review**. The maintainer (repo admin) can self-merge
   their *own* PRs via an admin bypass, so a solo merge is never blocked — while every *other*
   contributor's PR gets a genuine four-eyes review before it lands.
@@ -48,7 +48,7 @@ bumps the `Version` in [`SKILL.md`](SKILL.md) (and `version`/`date-released` in
 1. **Enrich the changelog.** In the open release PR, edit the new `CHANGELOG.md` section to add the
    curated "what + **why**" narrative (the prose this skill values), then mark the PR ready.
 2. **Merge the release PR.** Because release-please authored it with `GITHUB_TOKEN`, the
-   `leakage-guard` / `docs-render` / `shellcheck` checks don't auto-run on it; review the (generated) diff and
+   `leakage-guard` / `docs-render` / `shellcheck` / `skill-lint` / `script-tests` checks don't auto-run on it; review the (generated) diff and
    admin-merge: `gh pr merge --squash --admin`.
 3. **Cut the signed tag + GitHub Release** from the merged `main`:
    ```bash


### PR DESCRIPTION
## What changed
- `MAINTAINERS.md` → *How we work*: the required-check enumeration gains `skill-lint` + `script-tests`.
- `MAINTAINERS.md` → *Cutting a release* step 2: the list of checks that don't auto-run on GITHUB_TOKEN-authored release PRs gains both (same suppression applies to them).
- `CONTRIBUTING.md` → *How your PR gets reviewed and merged*: same enumeration updated.

## Why it changed
The `main-protection` ruleset was updated today (maintainer-authorized) to add `skill-lint` and `script-tests` to `required_status_checks` — live set now `docs-render, leakage-guard, shellcheck, skill-lint, script-tests` (verified via the rulesets API; approvals/bypass/other rules unchanged). Docs enumerating the required set must move in the same pass, per the docs-honesty discipline.

## Testing instructions
- `gh api repos/bjgreenberg/senior-engineering-partner/rulesets/18154173 --jq '.rules[] | select(.type=="required_status_checks")'` — matches the enumerations in this diff.
- `git grep -nE 'docs-render.*leakage-guard|required checks' -- '*.md'` — no remaining three-check enumerations outside CHANGELOG (append-only) and this PR.

**Review (recorded — docs-only enumeration diff, self-review):** ✅ Approve. Deterministic sweep: `git grep` over `*.md` for required-check enumerations found exactly these three sites; README carries live badges + per-gate prose that never claims the required set, so it needed no change. This PR itself merges under the new 5-check gate (dogfood proof).