### PR TITLE
fix(privacy): scrub environment-specific identifiers from baseline evidence strings

### DIFF
--- a/evals/baselines/2026-07-04-fable/baseline.json
+++ b/evals/baselines/2026-07-04-fable/baseline.json
@@ -1803,7 +1803,7 @@
     {
      "behavior": "Notes that the secret belongs in a secret manager (e.g. 1Password, the shipped default) and is referenced securely",
      "verdict": "unclear",
-     "evidence": "Says 'or use a proper secrets manager if RHR has one' \u2014 generic mention, not the shipped 1Password default and referenced somewhat as an afterthought"
+     "evidence": "Says 'or use a proper secrets manager if the organization has one' \u2014 generic mention, not the shipped 1Password default and referenced somewhat as an afterthought"
     },
     {
      "behavior": "Never logs the key/URL value at any level",

--- a/evals/baselines/2026-07-04-post-t4/with-skill-sonnet.json
+++ b/evals/baselines/2026-07-04-post-t4/with-skill-sonnet.json
@@ -437,7 +437,7 @@
     {
      "behavior": "Triages by surface instead of panicking wholesale: AES-256 at rest is already PQ-adequate (Grover only halves the margin); the HNDL exposure is key exchange/transport; signatures are not HNDL-exposed per se, BUT a signature re-verified after the transition (retained evidence verified at trial years later) needs trusted timestamping/countersigning",
      "verdict": "unclear",
-     "evidence": "Covers AES-256/Grover and key exchange as HNDL surface, and notes ed25519 'irrelevant to data confidentiality' plus chain-of-custody relevance, but never raises re-verification-at-trial horizon or timestamping/countersigning remedy."
+     "evidence": "Covers AES-256/Grover and key exchange as HNDL surface, and notes ed25519 'irrelevant to data confidentiality' plus evidence-custody relevance, but never raises re-verification-at-trial horizon or timestamping/countersigning remedy."
     },
     {
      "behavior": "Anchors the answer in the NIST post-quantum standards (FIPS 203/ML-KEM, FIPS 204/ML-DSA, FIPS 205/SLH-DSA, and/or the NIST IR 8547 trajectory \u2014 112-bit-strength classical deprecated ~2030, classical disallowed ~2035), with a verify-against-live-docs hedge rather than asserted-from-memory dates",
@@ -469,7 +469,7 @@
     {
      "behavior": "Treats ed25519 key recovery as the urgent harvest-now-decrypt-later risk while ignoring key exchange/transport, or conversely dismisses signatures entirely despite the 10-year re-verification horizon",
      "verdict": "clean",
-     "evidence": "Frames key exchange as the HNDL risk and notes ed25519 is a 'not PQC data point' for chain-of-custody signing rather than dismissing it."
+     "evidence": "Frames key exchange as the HNDL risk and notes ed25519 is a 'not PQC data point' for evidence-custody signing rather than dismissing it."
     },
     {
      "behavior": "Asserts specific standards, dates, or platform rollout claims with no verify-against-current-docs caveat",


### PR DESCRIPTION
## What changed
Three judge-evidence strings in the 2026-07-04 committed baselines carried Tier-2 denylist identifiers: an organization name in `2026-07-04-fable/baseline.json` and a domain fingerprint (×2) in `2026-07-04-post-t4/with-skill-sonnet.json`. Redacted with semantically-equivalent neutral wording; JSON validity re-verified; verdicts/judgments untouched.

## Why it changed
The Tier-2 leakage guard runs only where `references/leakage-denylist.local` exists — i.e. locally, never in CI (the documented #54 gap). #78 was authored and merged from an environment without the denylist, so its CI pass was Tier-1-only and these landed on public `main`. Caught by the local Tier-2 sweep during unrelated staging.

## Testing instructions
- `scripts/leakage-guard.sh` locally (Tier 2): PASS after this diff, 3 hits before it.
- `python3 -c 'import json; json.load(open("evals/baselines/2026-07-04-fable/baseline.json")); json.load(open("evals/baselines/2026-07-04-post-t4/with-skill-sonnet.json"))'` — both parse.

## Disclosures
- The identifiers survive in the #78 squash-commit blob in history (public repo) — same residual class as the #53 blob (rewrite = maintainer's call, judged low-severity there).
- Root-cause observation for a follow-up: the identifiers most plausibly entered via eval runs inheriting the invoking environment's global agent context (user-level memory/hooks load into headless `claude -p` runs — verified locally: SessionStart hooks fire inside scenario runs). Worth a harness-isolation decision; noted in the sharpening PR as well.

**Review (recorded — 4-file string redaction, deterministic self-review):** ✅ Approve. The guard is the oracle: fail→pass on exactly these three strings; no other bytes changed (`git diff --stat`: 2 files, 3 substitutions).