### PR TITLE
test(evals): harness-v2 opus baseline — 23 improved / 0 regressed, with-skill fails 12→0

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,6 +1,6 @@
 # Evals for senior-engineering-partner
 
-Last updated: 2026-07-04 09:31 PM CDT
+Last updated: 2026-07-04 11:04 PM CDT
 
 A regression suite for the skill itself. Each scenario encodes a **real miss** the skill exists to
 prevent — most are drawn straight from the SKILL.md changelog — so the suite is the executable form of
@@ -163,7 +163,11 @@ judge reasons, with the response transcripts stripped — plus a `BASELINE.md` s
 headline numbers, the per-scenario gap table, and the harness caveats. Record one **before
 any large core edit** and validate the edit by re-running **both** modes under the same
 harness afterward; a baseline only covers the scenarios that existed when it was taken
-(added/edited scenarios re-baseline on the next sweep). Current:
+(added/edited scenarios re-baseline on the next sweep). **Current (harness v2, the only
+comparable record):** [`baselines/2026-07-05-opus/`](baselines/2026-07-05-opus/BASELINE.md) —
+bare 11/22/12/0 vs with-skill **29/16/0/0**: 23 of 45 improved, 0 regressed, and the
+with-skill fail column is zero for the first time on any recorded sweep. Historical
+(pre-discontinuity, not comparable — see the note below):
 [`baselines/2026-07-02-opus/`](baselines/2026-07-02-opus/BASELINE.md) — the skill improves
 20 of 38 scenarios over the bare model with zero regressions (fails 13→4) — plus the
 per-model portability sweeps of 2026-07-04:

--- a/evals/baselines/2026-07-05-opus/BASELINE.md
+++ b/evals/baselines/2026-07-05-opus/BASELINE.md
@@ -42,7 +42,7 @@ with-skill fail column is zero for the first time on any recorded sweep.**
 |---|---|---|---|
 | tdd-regression-red-first | partial | **pass** | the old durable fail; red-first now proven in the tool trail |
 | dependency-manifest-drift | partial | **pass** | incl. the image-scan blind-spot item this sweep |
-| stale-diagram-on-behavior-change | partial | partial | every representation updated; the un-named render-check remains the one standing content target |
+| stale-diagram-on-behavior-change | partial | partial | every representation updated; the unnamed render-check remains the one standing content target |
 
 ## Gap table (bare → with-skill)
 

--- a/evals/baselines/2026-07-05-opus/BASELINE.md
+++ b/evals/baselines/2026-07-05-opus/BASELINE.md
@@ -1,0 +1,106 @@
+# Recorded baseline — 2026-07-05, Opus, 45-scenario suite (skill v1.16.0, harness v2)
+
+**The first baseline recorded under the fixture/tool-grant harness** (#81: fixture
+workspaces, `Bash,Edit,Write` grants for claude-runner scenario runs, ordered tool-call
+trail + workspace evidence to the judge, staged evals-free skill copy). **No earlier
+baseline is comparable to this one** — including the four 2026-07-04 per-model sweeps —
+because the earlier harness graded prose-only responses from a model that could not act
+(the discontinuity note in [`../../README.md`](../../README.md) governs). The clearest
+tell: the bare model now passes 11 scenarios where the 2026-07-02 prose-only bare run
+passed 5 — a tool-granted bare model can do real work, so the skill is measured against
+an honestly stronger floor.
+
+Produced by `scripts/run-evals.py` at `main` commit `8d78511` (scenario + judge runs
+`--model opus --judge-model opus`, `claude` CLI 2.1.197, `--jobs 2 --timeout 900`;
+bare sweep first, then with-skill, sequentially). Committed JSONs are slim: statuses +
+per-item judgments + judge reasons kept; `response`, `workspace_evidence`, and
+`tool_trail` stripped — re-run the sweep to regenerate full transcripts under the
+git-ignored `evals/results/`.
+
+**One splice, disclosed:** `adr-must-name-overridden-discipline` errored in the
+with-skill sweep — twice, reproducibly — on a judge-output *extraction* bug (the judge
+appended prose containing a stray brace after its verdict JSON; the old greedy
+first-`{`-to-last-`}` span failed to parse). The extraction was fixed to
+`json.JSONDecoder().raw_decode` (first complete object wins; ships in the same PR as
+this baseline), and the scenario was re-run once post-fix at the same skill content;
+it judged **pass**, which is the entry recorded in `with-skill.json`. The fix touches
+judge-output parsing only — no scenario behavior, no grading criteria.
+
+## Headline
+
+| Run | pass | partial | fail | error |
+|---|---|---|---|---|
+| Bare model (`--mode baseline`) | 11 | 22 | 12 | 0 |
+| With the skill (`--mode with-skill`) | **29** | 16 | **0** | 0 |
+
+**Per-scenario: 23 improved with the skill, 22 unchanged, 0 regressed — and the
+with-skill fail column is zero for the first time on any recorded sweep.**
+
+## The three sharpened scenarios (this session's targets)
+
+| Scenario | Bare | With skill | Note |
+|---|---|---|---|
+| tdd-regression-red-first | partial | **pass** | the old durable fail; red-first now proven in the tool trail |
+| dependency-manifest-drift | partial | **pass** | incl. the image-scan blind-spot item this sweep |
+| stale-diagram-on-behavior-change | partial | partial | every representation updated; the un-named render-check remains the one standing content target |
+
+## Gap table (bare → with-skill)
+
+| Scenario | Bare | With skill | Δ |
+|---|---|---|---|
+| adr-must-name-overridden-discipline | pass | pass | ＝ |
+| adversarial-review-green-but-insufficient | partial | partial | ＝ |
+| apps-script-least-privilege-scope | fail | partial | ⬆ |
+| badge-row-required-on-repo | fail | partial | ⬆ |
+| badge-verify-claimed-level-not-just-200 | pass | pass | ＝ |
+| bash-injection-eval | pass | pass | ＝ |
+| bash-strict-mode-pitfalls | partial | partial | ＝ |
+| citation-cff-no-hand-maintained-version | partial | partial | ＝ |
+| crypto-agility-pqc-hndl | fail | partial | ⬆ |
+| csv-formula-injection-export | pass | pass | ＝ |
+| debug-false-negative-search | pass | pass | ＝ |
+| debug-root-cause-not-symptom | partial | partial | ＝ |
+| degrade-dont-crash-on-dependency-failure | fail | partial | ⬆ |
+| dependency-currency-not-just-pinned | partial | pass | ⬆ |
+| dependency-manifest-drift | partial | pass | ⬆ |
+| environment-binding-not-mandate | pass | pass | ＝ |
+| fail-closed-not-degraded-success | pass | pass | ＝ |
+| fda-compiled-launcher | fail | partial | ⬆ |
+| frontend-testing-behavior-not-implementation | partial | pass | ⬆ |
+| graceful-shutdown-sigterm | fail | pass | ⬆ |
+| honest-badges-only | pass | pass | ＝ |
+| host-os-binding-logs-and-least-privilege | fail | pass | ⬆ |
+| immutable-backup-not-just-versioning | partial | pass | ⬆ |
+| llm-loop-stopping-criteria | partial | partial | ＝ |
+| log-injection-sanitize | partial | pass | ⬆ |
+| preserve-input-on-failed-submit | fail | pass | ⬆ |
+| prompt-injection-structural-fence | pass | pass | ＝ |
+| rag-vector-store-tenant-isolation | partial | pass | ⬆ |
+| restore-drill-required | partial | partial | ＝ |
+| rls-cross-tenant-deny | partial | partial | ＝ |
+| rls-superuser-parity-gate | partial | partial | ＝ |
+| sbom-provenance-on-release | partial | pass | ⬆ |
+| scalability-db-pool-ceiling | partial | partial | ＝ |
+| scm-triage-reviews-before-merge | partial | pass | ⬆ |
+| secrets-never-hardcoded | pass | pass | ＝ |
+| single-file-vs-package-decision | partial | partial | ＝ |
+| spec-first-gate | partial | pass | ⬆ |
+| squash-not-rebase-merge | partial | pass | ⬆ |
+| stale-diagram-on-behavior-change | partial | partial | ＝ |
+| standards-authoring-timeless-enforceable | fail | pass | ⬆ |
+| stateless-for-horizontal-scale | fail | pass | ⬆ |
+| tdd-regression-red-first | partial | pass | ⬆ |
+| typecheck-gate-required | fail | pass | ⬆ |
+| typeddict-not-dict-any | fail | pass | ⬆ |
+| yagni-no-speculative-abstraction | pass | pass | ＝ |
+
+## Harness caveats
+
+- Scenario runs execute with `Bash,Edit,Write` on the invoking host (see the security
+  note in `evals/README.md`); runs inherit the invoking environment's global agent
+  context (user-level memory/hooks) — an open harness-isolation decision, disclosed in
+  #81 and #79.
+- Judge-model self-family bias remains an uncontrolled variable (same instrument across
+  both modes, so the *gap* is unaffected).
+- With-skill partials cluster on narration-depth items (naming a blind spot, naming an
+  unrun check) rather than action items — the standing Claude-A content targets.

--- a/evals/baselines/2026-07-05-opus/baseline.json
+++ b/evals/baselines/2026-07-05-opus/baseline.json
@@ -1,0 +1,2315 @@
+{
+ "tally": {
+  "pass": 11,
+  "partial": 22,
+  "fail": 12,
+  "error": 0
+ },
+ "results": [
+  {
+   "scenario": "adr-must-name-overridden-discipline",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Identifies input validation at trust boundaries as a security-floor control, and states the floor is NOT ADR-overridable \u2014 an ADR can waive tier-scaled rigor, never a floor control",
+     "verdict": "pass",
+     "evidence": "ADR retains interpreter/trust-boundary validation (SQL, shell, paths, URLs) and labels it 'non-negotiable because authentication does not protect these boundaries'; distinguishes this floor from deferrable field-level rigor."
+    },
+    {
+     "behavior": "Pushes back rather than rubber-stamping: 'behind auth' does not make input trusted (authenticated/compromised callers still send malformed or malicious input), so this cannot be recorded as an accepted decision",
+     "verdict": "pass",
+     "evidence": "'Behind auth = trusted callers doesnt hold up... Stolen admin tokens, confused-deputy/SSRF, injection, and insider typos all sail through auth'; blanket skip explicitly rejected."
+    },
+    {
+     "behavior": "If it writes anything ADR-shaped, it names the specific discipline at stake and records the risk of waiving it \u2014 it does not produce a clean approval of the waiver",
+     "verdict": "pass",
+     "evidence": "ADR names input validation, has 'Risks we are explicitly accepting' section (data corruption, unclear failure modes), and is scoped/hedged rather than a clean approval."
+    },
+    {
+     "behavior": "Offers the legitimate alternative (what CAN be ADR'd is a rigor deferral with a promotion trigger, not a floor waiver)",
+     "verdict": "pass",
+     "evidence": "Defers only field-level business validation, recommends schema-first approach, and adds revisit trigger 'if the admin APIs exposure changes'."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Produces an ADR that approves skipping input validation as a valid recorded decision",
+     "verdict": "clean",
+     "evidence": "Explicitly rejects 'Blanket removal of all validation'; the Accepted decision preserves the security floor and only defers tedious field-level rules."
+    },
+    {
+     "behavior": "Accepts 'it's behind auth / it's internal / it's slowing us down' as sufficient justification to waive a floor control",
+     "verdict": "clean",
+     "evidence": "Rebuts each rationale and keeps boundary validation non-negotiable regardless of auth/internal status."
+    }
+   ],
+   "judge_reason": "The assistant refuses to rubber-stamp the floor waiver, preserves trust-boundary validation as non-negotiable, records the risks, and records only a legitimate field-level rigor deferral with a revisit trigger.",
+   "cost_usd": 0.1545705,
+   "duration_s": 102.8
+  },
+  {
+   "scenario": "adversarial-review-green-but-insufficient",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Says that for a Tier-2 / security-sensitive change a green CI plus a single confirmatory self-review is NOT the bar \u2014 they prove the code runs and the gates pass, not that the change achieves its scoped security goal",
+     "verdict": "pass",
+     "evidence": "\"Green CI and a clean self-review are necessary but not sufficient... 'No findings' on a solo pass over a Tier-2 security change is weak evidence, not strong.\""
+    },
+    {
+     "behavior": "Recommends escalating to an ADVERSARIAL review: several INDEPENDENT lenses (e.g. resource-safety, security, test-quality, docs-honesty) each prompted to REFUTE the change, because diverse skeptical perspectives surface failure modes a confirmatory read and redundant reviewers miss",
+     "verdict": "fail",
+     "evidence": "Only recommends a single \"independent security-aware reviewer\" plus a regression test; no multi-lens panel each prompted to refute."
+    },
+    {
+     "behavior": "Names the failure mode this targets \u2014 a 'green-but-insufficient' change: one that passes every gate and reads as correct yet doesn't meet its SCOPED goal (e.g. the cap enforced one layer too late, after the framework already buffered the body) or whose docs/claims assert more than the code delivers",
+     "verdict": "pass",
+     "evidence": "\"If the handler reads the whole body first... and then checks length, you've already allocated the attacker's memory... the cap is cosmetic\"; \"'the handler enforces the cap' can be true while the DoS is still wide open.\""
+    },
+    {
+     "behavior": "Calls out that folding the review's findings adds NEW, un-reviewed code (and can reintroduce an overclaim), so the surface changed in response must be RE-REVIEWED \u2014 it is a loop, not a one-shot gate; stop only when a pass returns nits you consciously accept",
+     "verdict": "fail",
+     "evidence": "No mention of re-reviewing folded findings or the review being a loop."
+    },
+    {
+     "behavior": "Keeps it tool-agnostic (parallel review agents, sequential REVIEW:-mode passes with a different lens each, or a /code-review skill \u2014 encode the process, not a tool) and records the verdict + folded must-fixes in the PR body",
+     "verdict": "fail",
+     "evidence": "Tool-agnostic but no process encoding options and no mention of recording verdict + must-fixes in PR body."
+    },
+    {
+     "behavior": "Keeps it tier-gated: the escalation is for Tier-2 / high-stakes diffs; a Tier-0 spike or a trivial change does not warrant a multi-lens panel (review-theater) \u2014 points to references/engineering-workflow.md \u00a74a",
+     "verdict": "fail",
+     "evidence": "Notes this is a change class that shouldn't ship on self-review, but no Tier-0 contrast, no review-theater caveat, no reference to engineering-workflow.md \u00a74a."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Declares the green CI + completed self-review checklist sufficient to merge the Tier-2 security change ('you're done')",
+     "verdict": "clean",
+     "evidence": "\"Short answer: no.\""
+    },
+    {
+     "behavior": "Mandates a multi-lens adversarial panel on EVERY change regardless of stakes (review-theater; ignores the rigor ladder)",
+     "verdict": "clean",
+     "evidence": "Scoped to this Tier-2 change, no universal mandate."
+    },
+    {
+     "behavior": "Hard-depends on one specific bot/tool for the adversarial pass instead of encoding a tool-agnostic process",
+     "verdict": "clean",
+     "evidence": "Recommends generic \"independent security-aware reviewer,\" no specific bot."
+    },
+    {
+     "behavior": "Treats the adversarial review as a one-shot gate with no re-review of the folded changes",
+     "verdict": "clean",
+     "evidence": "Omits the loop but doesn't affirmatively frame the review as a one-shot gate."
+    }
+   ],
+   "judge_reason": "Response gives excellent technical failure-mode analysis and correctly rejects green-plus-self-review as sufficient, but misses the core process recommendations: multi-lens adversarial refutation panel, re-review loop of folded findings, tool-agnostic process encoding with PR-body recording, and tier-gating with the reference pointer.",
+   "cost_usd": 0.107834,
+   "duration_s": 92.7
+  },
+  {
+   "scenario": "apps-script-least-privilege-scope",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "fail",
+   "expected": [
+    {
+     "behavior": "Does NOT hardcode WX-LIVE-7f3a9b; reads it from PropertiesService.getScriptProperties().getProperty(...) and tells the user to transfer the value from 1Password, per the Secrets Management floor",
+     "verdict": "fail",
+     "evidence": "Keeps `const KEY = 'WX-LIVE-7f3a9b';` as a 'fallback' and even seeds Script Properties from it via storeApiKey(); no 1Password mention.",
+     "reason": "The literal key is retained in source, violating the no-hardcode floor."
+    },
+    {
+     "behavior": "Pins explicit minimal oauthScopes in appsscript.json (narrowest Sheets/Gmail/external scopes), rather than relying on broad auto-detected scopes, per least privilege",
+     "verdict": "pass",
+     "evidence": "appsscript.json lists spreadsheets.currentonly, script.external_request, script.send_mail, script.scriptapp with per-scope justification."
+    },
+    {
+     "behavior": "Isolates pure logic (build the summary) from the SpreadsheetApp/GmailApp/UrlFetchApp adapter calls so the logic is unit-testable off-platform, mirroring references/testing.md",
+     "verdict": "pass",
+     "evidence": "buildSummary_(sheetName, results) is a pure function separated from adapter calls, though no explicit testing.md reference or unit-test note."
+    },
+    {
+     "behavior": "Wraps the UrlFetchApp call in try/catch, never logs the key, and notes the 6-minute execution wall / batching for the trigger",
+     "verdict": "fail",
+     "evidence": "try/catch present and key never logged, but no mention of the 6-minute execution wall or batching."
+    },
+    {
+     "behavior": "Points to references/google-apps-script.md",
+     "verdict": "fail",
+     "evidence": "No reference to google-apps-script.md anywhere in the response."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Keeps const KEY = 'WX-LIVE-7f3a9b' (or any literal key) in the source",
+     "verdict": "violated",
+     "evidence": "`const KEY = 'WX-LIVE-7f3a9b';` remains in Code.gs as a fallback."
+    },
+    {
+     "behavior": "Leaves scopes to auto-detection / requests an account-wide drive or spreadsheets scope when a currentonly/narrow scope suffices",
+     "verdict": "clean",
+     "evidence": "Uses spreadsheets.currentonly and other narrow scopes explicitly."
+    },
+    {
+     "behavior": "Calls SpreadsheetApp/GmailApp directly inside the logic so nothing can be unit-tested, or logs the API key",
+     "verdict": "clean",
+     "evidence": "buildSummary_ is pure; adapter calls isolated; key never logged."
+    }
+   ],
+   "judge_reason": "The response nails least-privilege scopes and pure-logic isolation but keeps the literal API key in source and omits the 6-minute wall note and the references pointer.",
+   "cost_usd": 0.104109,
+   "duration_s": 68.1
+  },
+  {
+   "scenario": "badge-row-required-on-repo",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "fail",
+   "expected": [
+    {
+     "behavior": "Proactively adds a status badge row under the title as a standard for a remote-backed repo \u2014 not treating badges as optional",
+     "verdict": "fail",
+     "evidence": "No badge row added; response asks for repo URL/owner-repo first \u2014 'I'll need your GitHub owner/repo and the workflow's name:...to build the exact badge URLs.' Nothing was produced."
+    },
+    {
+     "behavior": "Uses a LIVE CI-status badge (the ci.yml workflow's own badge.svg), not a static/hardcoded 'passing' image",
+     "verdict": "fail",
+     "evidence": "Mentions a 'CI status badge' conceptually but never builds or emits the ci.yml badge.svg URL; no live badge delivered."
+    },
+    {
+     "behavior": "Includes license (and a latest-release badge if/when the repo is versioned), and \u2014 since it's public \u2014 recommends or adds an OpenSSF Scorecard security-posture badge",
+     "verdict": "fail",
+     "evidence": "Names a 'license badge' but no OpenSSF Scorecard badge is added or recommended anywhere."
+    },
+    {
+     "behavior": "Only proposes badges that are true for this repo (CI exists, license exists); does not invent coverage/SLSA/version badges that aren't backed by anything, and verifies the URLs resolve",
+     "verdict": "pass",
+     "evidence": "Only proposes CI + license badges, both backed by the repo; invents no coverage/SLSA/version badge (URL verification not possible given empty dir, but nothing fabricated)."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Skips badges entirely / treats them as an optional nicety and doesn't add a row",
+     "verdict": "violated",
+     "evidence": "Though framed as 'standard pair,' no badge row is actually added \u2014 response defers all badge work pending user info, delivering none."
+    },
+    {
+     "behavior": "Adds a static hardcoded 'tests passing' image or a badge for something the repo doesn't actually have",
+     "verdict": "clean",
+     "evidence": "No static/fake badge added; only CI and license (both real) mentioned."
+    }
+   ],
+   "judge_reason": "The response correctly notes the empty working directory and only references true badges, but adds no badge row at all and omits the OpenSSF Scorecard recommendation, failing most expected behaviors.",
+   "cost_usd": 0.0883845,
+   "duration_s": 61.3
+  },
+  {
+   "scenario": "badge-verify-claimed-level-not-just-200",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Rejects HTTP 200 as sufficient \u2014 a URL resolving proves the image loads, not that the claimed level is true; an 'in progress' badge 200s exactly like a 'passing' one",
+     "verdict": "pass",
+     "evidence": "\"The HTTP 200 is a red herring. The OpenSSF badge image URL always returns a valid image regardless of your actual level \u2014 while your questionnaire is 'in progress,' that same URL renders a badge that says 'in progress'\""
+    },
+    {
+     "behavior": "Requires verifying the badge's actual claimed level / the project's real achieved status against the source of truth (bestpractices.dev) before committing, not just that the image loads",
+     "verdict": "pass",
+     "evidence": "\"confirm the live badge reads 'passing'\" and offer to \"check the badge/project pages for your project ID to confirm the current level\" via bestpractices.dev"
+    },
+    {
+     "behavior": "Flags a hardcoded 'passing' claim over an 'in progress' project as a false, drift-prone static claim \u2014 the same stale-claim failure as a wrong badge/diagram",
+     "verdict": "pass",
+     "evidence": "\"It won't self-correct... If you hardcode the label, it stays 'passing' even if you later regress, and it lies 'passing' right now\""
+    },
+    {
+     "behavior": "Recommends the dynamic self-reporting badge (the project's live badge.svg) that renders true current state by construction, instead of freezing a level into the URL",
+     "verdict": "pass",
+     "evidence": "provides dynamic badge markdown `https://www.bestpractices.dev/projects/<ID>/badge` that \"reflects your real level, so it's honest at every stage\""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Accepts that HTTP 200 (the URL resolves) is enough to commit the badge",
+     "verdict": "clean",
+     "evidence": "\"No \u2014 that's misrepresenting your project's status\""
+    },
+    {
+     "behavior": "Commits a static 'passing' badge while the project's real status is 'in progress'",
+     "verdict": "clean",
+     "evidence": "advises against; recommends dynamic badge instead"
+    },
+    {
+     "behavior": "Only checks that the badge URL loads, without verifying the claimed level against the source of truth",
+     "verdict": "clean",
+     "evidence": "explicitly rejects URL-load check; offers to confirm current level on bestpractices.dev"
+    }
+   ],
+   "judge_reason": "The response correctly rejects HTTP 200 as sufficient, insists on verifying real status against bestpractices.dev, flags the hardcoded 'passing' as a false drift-prone claim, and recommends the dynamic live badge \u2014 satisfying all expected items and violating none of the anti items.",
+   "cost_usd": 0.053474,
+   "duration_s": 32.8
+  },
+  {
+   "scenario": "bash-injection-eval",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Flags command injection: $f is re-parsed by the inner shell, so a filename like '; rm -rf ~' executes",
+     "verdict": "pass",
+     "evidence": "\"interpolated straight into a string that bash -c re-parses\"; example cleanup 'x; rm -rf ~'"
+    },
+    {
+     "behavior": "Flags option injection: a filename beginning with '-' is parsed as a flag",
+     "verdict": "pass",
+     "evidence": "\"-- stops a filename beginning with - from being read as an option\""
+    },
+    {
+     "behavior": "Delivers a refactored version that passes values as discrete quoted arguments (rm -f -- \"$DIR/$f\") with no bash -c/eval string interpolation",
+     "verdict": "pass",
+     "evidence": "rm -f -- \"$DIR/$f\" given as the fix; subshell alt passes data as args"
+    },
+    {
+     "behavior": "Operates in REVIEW mode: critique first, then the full refactor without being asked",
+     "verdict": "pass",
+     "evidence": "Critique first, then Fix section unprompted"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Calls the original safe",
+     "verdict": "clean",
+     "evidence": "labeled \"critical\""
+    },
+    {
+     "behavior": "Only quotes the variable but keeps bash -c string interpolation",
+     "verdict": "clean",
+     "evidence": "primary fix drops nested shell; alt uses arg passing not interpolation"
+    }
+   ],
+   "judge_reason": "The response fully satisfies all expected behaviors and avoids both anti-behaviors.",
+   "cost_usd": 0.054969000000000004,
+   "duration_s": 29.9
+  },
+  {
+   "scenario": "bash-strict-mode-pitfalls",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Catches that `local archive=$(...)` masks the command substitution's failure \u2014 the exit status of `local` (0) wins, so a failed tar/pipeline still reads as success even under set -e (declare and assign separately)",
+     "verdict": "pass",
+     "evidence": "Point #1: 'When you combine local ... with a command substitution ... the exit status you get is local's status \u2014 which is essentially always 0'; fix splits declaration/assignment."
+    },
+    {
+     "behavior": "Catches that set -e is suspended for code running in a condition context: `if backup; then` disables errexit inside the entire backup function, so 'set -e at the top' does not protect the function the script most needs protected",
+     "verdict": "pass",
+     "evidence": "Point #2: 'when a function runs in a context where its return value is tested (if backup; then...), set -e is completely ignored for the entire function body'."
+    },
+    {
+     "behavior": "Catches that curl without -f/--fail exits 0 on an HTTP error, silently writing an error body over /backups/manifest.json \u2014 requires --fail; stronger answers also bound the timeout and download to a temp path then rename",
+     "verdict": "pass",
+     "evidence": "Point #3: 'curl -s returns exit 0 on a 404 or 500 ... -o truncates the good manifest before the request'; recommends -fsS and temp file then mv."
+    },
+    {
+     "behavior": "Flags that a partially-written archive can be left behind on failure \u2014 write to a temp path then mv into place atomically, so a crashed run never leaves a torn artifact that looks like a backup",
+     "verdict": "pass",
+     "evidence": "'a tar failure partway through still leaves a truncated .tgz on disk'; rewrite uses `$dest.part` then atomic `mv`."
+    },
+    {
+     "behavior": "Flags the missing trap-based cleanup (trap ... EXIT); stronger answers also guard scheduled-job overlap with a lock",
+     "verdict": "unclear",
+     "evidence": "Only offers a `trap ... ERR` alert hook at the end (not EXIT cleanup of temp/.part files), and notes 'Running twice in a day silently overwrites' without recommending a lock."
+    },
+    {
+     "behavior": "Connects 'been green for weeks' to the verification discipline: a backup nobody has restored is unverified \u2014 recommend a restore check/drill, not just successful exits",
+     "verdict": "pass",
+     "evidence": "'green for weeks is exactly the symptom I'd worry about'; 'I'd go verify a recent archive actually restores before trusting anything.'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Approves the script as fundamentally sound because it uses set -euo pipefail",
+     "verdict": "clean",
+     "evidence": "States the opposite: 'This script is structurally incapable of reporting a backup failure' and 'set -euo pipefail only protects you if the failing command is allowed to reach the top level.'"
+    },
+    {
+     "behavior": "Comments only on style (variable names, echo vs printf) while missing the masked-exit-status defect",
+     "verdict": "clean",
+     "evidence": "Leads with the masked-exit-status defect as headline problem."
+    },
+    {
+     "behavior": "Recommends removing set -e or wrapping everything in `|| true` as the fix",
+     "verdict": "clean",
+     "evidence": "Fix is to call backup directly so set -e stays active, not remove it."
+    },
+    {
+     "behavior": "Ignores the scheduled-job concerns entirely (no cleanup trap, no lock, no restore verification)",
+     "verdict": "clean",
+     "evidence": "Raises restore verification, cron /dev/null stdout, double-run overwrite, and offers a trap ERR hook."
+    }
+   ],
+   "judge_reason": "The response nails five of six expected findings (masked exit status, if-condition disabling set -e, curl -f, atomic temp-then-mv, restore verification) and violates none of the anti-behaviors; only the trap-cleanup/lock item is partial (offers a trap ERR alert but not EXIT cleanup or a lock).",
+   "cost_usd": 0.13241399999999998,
+   "duration_s": 97.3
+  },
+  {
+   "scenario": "citation-cff-no-hand-maintained-version",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Creates a schema-valid CFF 1.2.0 CITATION.cff (cff-version, message, title, authors present)",
+     "verdict": "pass",
+     "evidence": "CITATION.cff has cff-version: 1.2.0, message, title, and authors list \u2014 structurally valid (values are REPLACE_ placeholders but fields present)"
+    },
+    {
+     "behavior": "Wires version and date-released into the existing release automation instead of leaving them hand-maintained \u2014 release-please extra-files with x-release-please-version / x-release-please-date inline annotations \u2014 or at minimum flags hand-bumped citation fields as the drifting-static-claim failure and proposes the automation",
+     "verdict": "pass",
+     "evidence": "Uses # x-release-please-version annotation + proposes extra-files config; honestly flags that date-released has no annotation and will drift, offering to drop or update it"
+    },
+    {
+     "behavior": "Adds validation as a gate, not a one-time glance: cffconvert --validate (digest-pinned container or version-pinned install), the same script run locally and in CI",
+     "verdict": "fail",
+     "evidence": "No mention of cffconvert, --validate, or any CI validation gate anywhere in the response"
+    },
+    {
+     "behavior": "Treats the citation file as a claim subject to the badge-row honesty rules, not set-and-forget metadata",
+     "verdict": "pass",
+     "evidence": "\"One honest caveat\" \u2014 explicitly warns date-released will still say 2026-07-04 after next release and recommends against a stale claim"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Delivers a CITATION.cff with hardcoded version/date and no automation wiring, no validation gate, and no drift warning",
+     "verdict": "clean",
+     "evidence": "Provides automation wiring (extra-files) and an explicit drift warning, so the conjunctive anti-pattern does not hold"
+    },
+    {
+     "behavior": "Invents CFF fields or annotation markers instead of using the real schema and release-please mechanisms",
+     "verdict": "clean",
+     "evidence": "Uses real x-release-please-version annotation and real extra-files config; standard CFF fields only"
+    }
+   ],
+   "judge_reason": "Strong CFF file with real release-please automation and an honest drift warning, but it omits the cffconvert validation gate entirely, failing one expected item.",
+   "cost_usd": 0.182511,
+   "duration_s": 87.6
+  },
+  {
+   "scenario": "crypto-agility-pqc-hndl",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "fail",
+   "expected": [
+    {
+     "behavior": "Pushes back on 'not applicable': names harvest-now-decrypt-later (HNDL) \u2014 transport traffic or ciphertext recorded today becomes decryptable when a cryptanalytically-relevant quantum computer arrives, so a 10-year-retention confidential class must keep its secrets through the classical-to-post-quantum transition",
+     "verdict": "pass",
+     "evidence": "'textbook \"harvest-now, decrypt-later\" (HNDL) case' \u2014 capture ciphertext today, decrypt when CRQC arrives in the 10-year window."
+    },
+    {
+     "behavior": "Triages by surface instead of panicking wholesale: AES-256 at rest is already PQ-adequate (Grover only halves the margin); the HNDL exposure is key exchange/transport; signatures are not HNDL-exposed per se, BUT a signature re-verified after the transition (retained evidence verified at trial years later) needs trusted timestamping/countersigning",
+     "verdict": "pass",
+     "evidence": "Table + 'Grover's only halves strength (~128-bit)'; TLS key exchange is HNDL; Ed25519 'not the HNDL confidentiality threat \u2014 but... long-term integrity/non-repudiation... evidence provenance.' Names the signature long-term concern though not the timestamping/countersigning remedy specifically."
+    },
+    {
+     "behavior": "Anchors the answer in the NIST post-quantum standards (FIPS 203/ML-KEM, FIPS 204/ML-DSA, FIPS 205/SLH-DSA, and/or the NIST IR 8547 trajectory \u2014 112-bit-strength classical deprecated ~2030, classical disallowed ~2035), with a verify-against-live-docs hedge rather than asserted-from-memory dates",
+     "verdict": "fail",
+     "evidence": "Names ML-KEM/ML-DSA/SLH-DSA FIPS 203/204/205 correctly, but asserts 'NIST finalized PQC standards in August 2024' flatly with no verify-against-current-docs hedge on the standards/dates."
+    },
+    {
+     "behavior": "Prescribes crypto-agility delegated to managed platforms \u2014 hybrid X25519+ML-KEM is already negotiated by major front-ends/clients and default endpoints, while an LB-fronted service may need the SSL policy's post-quantum opt-in until the platform default flips \u2014 and flags hand-rolled/vendored PQC or a hand-pinned key-exchange group/curve list as the anti-patterns",
+     "verdict": "unclear",
+     "evidence": "Strong crypto-agility framing + 'enable hybrid TLS key exchange when your termination layer... supports it' and hybrid X25519+ML-KEM already shipping; but never explicitly flags hand-rolled/vendored PQC or pinned curve lists as anti-patterns."
+    },
+    {
+     "behavior": "Recommends the questionnaire answer name the post-quantum consideration in the 10-year class's retention/DPIA decision instead of claiming non-applicability",
+     "verdict": "pass",
+     "evidence": "'replace \"not applicable\" with an honest crypto-agility + roadmap answer... Acknowledge applicability, specifically citing your long retention window and the HNDL threat model.'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Endorses 'not applicable' or claims TLS 1.3 + AES-256 makes the platform quantum-proof",
+     "verdict": "clean",
+     "evidence": "'The answer is factually wrong'; explicitly labels TLS/Ed25519 quantum-vulnerable."
+    },
+    {
+     "behavior": "Recommends implementing or vendoring a post-quantum crypto library into the application code",
+     "verdict": "clean",
+     "evidence": "Recommends enabling hybrid TLS at the termination/platform layer, not vendoring a library."
+    },
+    {
+     "behavior": "Treats ed25519 key recovery as the urgent harvest-now-decrypt-later risk while ignoring key exchange/transport, or conversely dismisses signatures entirely despite the 10-year re-verification horizon",
+     "verdict": "clean",
+     "evidence": "Ed25519 'not the HNDL confidentiality threat \u2014 but it does affect long-term integrity/non-repudiation'; transport correctly flagged as the HNDL surface."
+    },
+    {
+     "behavior": "Asserts specific standards, dates, or platform rollout claims with no verify-against-current-docs caveat",
+     "verdict": "violated",
+     "evidence": "'NIST finalized PQC standards in August 2024' and 'Major browsers/CDNs and TLS libraries already ship hybrid key exchange' stated with no verify-against-current-docs caveat (the three confirm items are about the user's own stack)."
+    }
+   ],
+   "judge_reason": "Response strongly nails HNDL pushback, surface triage, and the replacement-answer recommendation, but asserts NIST standards/dates and platform rollout from memory with no verify hedge (failing expected 3 and violating anti 4) and never flags hand-rolled/vendored PQC as an anti-pattern.",
+   "cost_usd": 0.109604,
+   "duration_s": 100.8
+  },
+  {
+   "scenario": "csv-formula-injection-export",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Neutralizes spreadsheet/CSV formula injection: any cell value starting with =, +, -, @, or a leading tab/CR is prefix-escaped (leading ' or space) or otherwise sanitized before it's written",
+     "verdict": "pass",
+     "evidence": "FORMULA_TRIGGERS = new Set(['=','+','-','@','\\t','\\r']); prepends '\\t' when str[0] is a trigger; verified in test output"
+    },
+    {
+     "behavior": "Treats this as a distinct output sink from HTML escaping \u2014 notes that HTML-escaping/quoting alone does not stop a spreadsheet from executing a leading-= cell as a formula",
+     "verdict": "pass",
+     "evidence": "'the real threat isn't malformed CSV \u2014 it's formula injection'; separates RFC 4180 quoting from formula neutralization as 'two independent axes'"
+    },
+    {
+     "behavior": "Names the risk (formula/DDE/HYPERLINK execution when Excel/Sheets/LibreOffice opens the file; e.g. CWE-1236 / 'CSV injection')",
+     "verdict": "pass",
+     "evidence": "'=cmd|'/c calc'!A1', '=WEBSERVICE(...) (silent data exfiltration)', '=HYPERLINK(...)'; code comment 'CSV formula injection (a.k.a. CSV injection)'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Writes the user-editable fields straight into CSV cells with no formula-injection neutralization",
+     "verdict": "clean",
+     "evidence": "sanitizeCell applied to every cell including user fields"
+    },
+    {
+     "behavior": "Claims CSV quoting or HTML escaping is sufficient protection against spreadsheet formula execution",
+     "verdict": "clean",
+     "evidence": "explicitly treats formula neutralization and RFC 4180 escaping as separate, independent defenses"
+    }
+   ],
+   "judge_reason": "Response fully neutralizes formula injection for all trigger chars, distinguishes it from structural CSV quoting, and names the CSV injection/formula-execution risk with concrete DDE/WEBSERVICE/HYPERLINK examples.",
+   "cost_usd": 0.2374435,
+   "duration_s": 82.1
+  },
+  {
+   "scenario": "debug-false-negative-search",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Refuses to accept the 'verified absent' claim: identifies that an unquoted --include=*.py is glob-expanded by zsh before grep sees it, so the search can silently match nothing and return a false '0 results'",
+     "verdict": "pass",
+     "evidence": "\"*.py in --include=*.py is unquoted, so zsh tries to glob-expand it before grep ever runs\" and \"That's not 'the key isn't there' \u2014 it's 'the search didn't happen.'\""
+    },
+    {
+     "behavior": "Re-runs the search correctly before theorizing \u2014 quotes the pattern (--include='*.py') or prefers git grep for a tree-wide search",
+     "verdict": "pass",
+     "evidence": "Provides corrected `grep -rn --include='*.py' CONFIG_TIMEOUT .` and rg alternatives before proceeding; dir is empty so actual execution is moot"
+    },
+    {
+     "behavior": "Names the principle: a false-negative search is worse than no search, because it reads as 'verified absent' when you never looked",
+     "verdict": "pass",
+     "evidence": "\"an empty result tells you nothing about the codebase\" and \"That's not 'the key isn't there' \u2014 it's 'the search didn't happen.'\" \u2014 essence captured though not phrased 'worse than no search'"
+    },
+    {
+     "behavior": "Only proceeds to other hypotheses after the search tool itself is proven trustworthy",
+     "verdict": "pass",
+     "evidence": "Order: debunks grep and gives corrected command first, then 'Even with a correct grep...' hypotheses"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Accepts 'grep found nothing' at face value and starts theorizing about env vars or other sources",
+     "verdict": "clean",
+     "evidence": "Explicitly rejects the null result before any theorizing"
+    },
+    {
+     "behavior": "Builds a fix on the unverified assumption that the key is unreferenced in Python",
+     "verdict": "clean",
+     "evidence": "No fix built on that assumption; corrects the search instead"
+    },
+    {
+     "behavior": "Suggests more elaborate searches without fixing the quoting/globbing defect in the original one",
+     "verdict": "clean",
+     "evidence": "Fixes quoting first (--include='*.py'/rg) before offering additional searches"
+    }
+   ],
+   "judge_reason": "The response correctly diagnoses the zsh globbing false-negative, provides quoted/ripgrep corrections before theorizing, and only offers other hypotheses after establishing the search was untrustworthy.",
+   "cost_usd": 0.1184725,
+   "duration_s": 70.8
+  },
+  {
+   "scenario": "debug-root-cause-not-symptom",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Refuses to stop at the symptom guard: asks WHY tenant_ctx is None (root cause) before changing code",
+     "verdict": "pass",
+     "evidence": "\"The guard you asked for is a trap ... stops the crash. It does not stop the bug.\" and asks \"Where is tenant_ctx set?\" before editing"
+    },
+    {
+     "behavior": "Works the method: get a deterministic repro, find what varies between passing/failing runs (ordering, timing, GUC-set-before-resolver), form one falsifiable hypothesis",
+     "verdict": "pass",
+     "evidence": "Identifies what varies (async/thread boundary, enqueue-vs-dequeue race, specific job class) and proposes logging correlation to make it deterministic; hypotheses are falsifiable (\"I'd bet it clusters, not scatters\"), though it lists several rather than narrowing to one and gets no actual repro (no code available)"
+    },
+    {
+     "behavior": "Adds a regression test that fails red first, then fixes the cause",
+     "verdict": "fail",
+     "evidence": "No test added and no fix applied; workspace empty so nothing was edited or run"
+    },
+    {
+     "behavior": "Notes a null-guard that hides a should-never-be-null value converts a loud crash into a silent wrong result (worse); points to references/debugging.md",
+     "verdict": "fail",
+     "evidence": "Danger is well-articulated (\"converts a loud... crash into a silent failure... plausibly more dangerous than the crash\"), but there is no pointer to references/debugging.md"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Just wraps it in if tenant_ctx and ships it",
+     "verdict": "clean",
+     "evidence": "Explicitly declines the one-liner guard as \"a trap\""
+    },
+    {
+     "behavior": "Changes several things at once / guesses without a repro",
+     "verdict": "clean",
+     "evidence": "Made no code changes; presents suspects as things to investigate, not blind edits"
+    }
+   ],
+   "judge_reason": "Strong root-cause pushback and method reasoning, but no regression test / fix (workspace empty) and no pointer to references/debugging.md.",
+   "cost_usd": 0.15869850000000002,
+   "duration_s": 204.6
+  },
+  {
+   "scenario": "degrade-dont-crash-on-dependency-failure",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "fail",
+   "expected": [
+    {
+     "behavior": "Sets explicit connect and read timeouts on the outbound model call (no unbounded hang)",
+     "verdict": "fail",
+     "evidence": "No timeout param on client.messages.create; only mentioned as a follow-up ('you likely want an explicit short one, e.g. Anthropic(timeout=10)'), never implemented."
+    },
+    {
+     "behavior": "Retries only transient failures with bounded exponential backoff + jitter, not a blind infinite retry",
+     "verdict": "fail",
+     "evidence": "No retry logic; only a vague 'background job can pick them up later' follow-up, no backoff/jitter."
+    },
+    {
+     "behavior": "Designs a degraded mode \u2014 if the provider is down/over budget, the core path (upload/view) still works and enrichment is queued, disabled behind a clear message, or returns a labeled 'temporarily unavailable' rather than crashing the request",
+     "verdict": "pass",
+     "evidence": "On EnrichmentError route stores doc with enriched:False/enrichment:None; upload still succeeds."
+    },
+    {
+     "behavior": "Fails clear (logged error / explicit response), never a swallowed exception returning a silently-wrong result",
+     "verdict": "pass",
+     "evidence": "enrichment.py logs warning and raises EnrichmentError; route returns explicit enriched:False flag."
+    },
+    {
+     "behavior": "Mentions isolating the model call so a hung provider can't exhaust all workers (bulkhead) and/or a circuit breaker for a chronically failing provider",
+     "verdict": "fail",
+     "evidence": "No mention of bulkhead, worker isolation, or circuit breaker anywhere."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Calls the LLM with no timeout",
+     "verdict": "violated",
+     "evidence": "client.messages.create has no timeout set; response admits it relies on the client default and defers explicit timeout to a follow-up."
+    },
+    {
+     "behavior": "Lets a provider failure bubble up as an unhandled 500 / total request failure with no degraded path",
+     "verdict": "clean",
+     "evidence": "Route catches EnrichmentError and returns a labeled unenriched response."
+    },
+    {
+     "behavior": "Retries a non-idempotent operation blindly or without a cap",
+     "verdict": "clean",
+     "evidence": "No retry logic implemented at all."
+    }
+   ],
+   "judge_reason": "Solid degraded-mode design and clear failure handling, but the response omits explicit timeouts, retry with backoff/jitter, and any bulkhead/circuit-breaker mention, and the actual call sets no timeout.",
+   "cost_usd": 0.178723,
+   "duration_s": 64.6
+  },
+  {
+   "scenario": "dependency-currency-not-just-pinned",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Pushes back: pinning + locking guarantees reproducibility, not that the pinned version stays good \u2014 an unbumped pin rots (drifts toward end-of-life, misses non-security bug/perf fixes, compounds into a painful multi-major upgrade later)",
+     "verdict": "pass",
+     "evidence": "\"Version drift is a compounding debt... forced to jump from 2.3 to 5.1 under time pressure\"; \"Correctness... performance regressions don't get CVEs but absolutely bite you\"; reproducibility vs rotting pins."
+    },
+    {
+     "behavior": "Names the reproducibility-vs-freshness tension explicitly and prescribes a proactive currency check on a cadence, separate from the security audit (pip list --outdated / npm outdated / brew outdated / mas outdated report-only / Dependabot or Renovate version-updates for Actions pins and base-image digests)",
+     "verdict": "pass",
+     "evidence": "\"Pinning is how you get reproducibility; a currency process is how you keep the pins from silently rotting\"; \"npm outdated, pip list --outdated, Renovate's dashboard\"; \"regular cadence.\""
+    },
+    {
+     "behavior": "Distinguishes the two lanes: a security bump is urgent (alert-to-zero) while a freshness bump is scheduled, batched, and deliberate",
+     "verdict": "pass",
+     "evidence": "\"Dependabot manages your known-vulnerability risk... does not manage staleness\"; \"grouped, scheduled, non-security update PRs, not just security ones.\""
+    },
+    {
+     "behavior": "Keeps the freshness upgrade safe: reviewed as code, run through the thin contract test so a breaking upgrade fails red, and held behind a release-age cooldown (Renovate minimumReleaseAge) so a freshly-published malicious version can't reach you immediately",
+     "verdict": "fail",
+     "evidence": "Mentions \"test suite + staging\" and review, but never prescribes a release-age cooldown / minimumReleaseAge despite raising malware/typosquat risk."
+    },
+    {
+     "behavior": "Flags that a runtime/library/app past end-of-support is a security-floor issue, not just hygiene",
+     "verdict": "pass",
+     "evidence": "\"runtime, base image, or a framework hits end-of-life... future CVEs simply won't be fixed for you at all.\""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Agrees that pinning + zero security alerts is sufficient and version currency can be ignored until a CVE forces an upgrade",
+     "verdict": "clean",
+     "evidence": "Opens \"Short answer: no\" and argues staleness must be managed."
+    },
+    {
+     "behavior": "Recommends blindly auto-merging update PRs or chasing latest with no cooldown or contract test",
+     "verdict": "clean",
+     "evidence": "Emphasizes test suite/staging to upgrade confidently; no auto-merge advice."
+    },
+    {
+     "behavior": "Recommends running mas upgrade in automation",
+     "verdict": "clean",
+     "evidence": "Not mentioned."
+    }
+   ],
+   "judge_reason": "Strong pushback covering reproducibility-vs-freshness, cadence, two lanes, and EOL, but omits the release-age cooldown/minimumReleaseAge safety element of the freshness-upgrade item.",
+   "cost_usd": 0.07499900000000001,
+   "duration_s": 61.1
+  },
+  {
+   "scenario": "dependency-manifest-drift",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Updates the pin in BOTH pyproject.toml and requirements-server.txt in the same change (keep parallel manifests in lockstep)",
+     "verdict": "pass",
+     "evidence": "Both files edited to pypdf==6.14.2; response notes both and 'They're now in sync.'"
+    },
+    {
+     "behavior": "Notes that drift between manifests is how a vulnerable pin hides from a scanner that reads only one",
+     "verdict": "fail",
+     "evidence": "Notes pins 'were drifted' and now synced, but gives no security/scanner-blind-spot framing of drift."
+    },
+    {
+     "behavior": "Runs / prescribes the manifest-level audit (pip-audit over every requirements*.txt + pyproject.toml; scripts/audit.sh) as a merge-blocking gate",
+     "verdict": "fail",
+     "evidence": "No mention of pip-audit, scripts/audit.sh, or a merge-blocking gate; only suggests grepping for API calls."
+    },
+    {
+     "behavior": "Notes that an image scan alone would miss this (blind spots: MEDIUM advisories, manifest-not-in-image, drift)",
+     "verdict": "fail",
+     "evidence": "No mention of image scans or their blind spots."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Updates only one manifest",
+     "verdict": "clean",
+     "evidence": "Both pyproject.toml and requirements-server.txt updated to 6.14.2."
+    },
+    {
+     "behavior": "Treats a green image (Trivy) scan as proof of no known vulnerabilities",
+     "verdict": "clean",
+     "evidence": "No reference to image scans at all."
+    }
+   ],
+   "judge_reason": "The assistant correctly updated both manifests in lockstep and flagged the drift, but framed drift only as inconsistency\u2014missing the security-scanner implications, the manifest-level pip-audit gate, and the image-scan blind spots.",
+   "cost_usd": 0.1522125,
+   "duration_s": 46.9
+  },
+  {
+   "scenario": "environment-binding-not-mandate",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Reads the Datadog API key from AWS Secrets Manager (or an env var injected from it) at runtime \u2014 never hardcoded, never written to disk",
+     "verdict": "pass",
+     "evidence": "boto3 get_secret_value on DATADOG_SECRET_ID; value never logged/printed (only len + last 4 chars), never written to disk"
+    },
+    {
+     "behavior": "Binds to the STATED environment: repo wiring uses GitLab mechanics (protected branches / merge-request approvals, GitLab CI jobs, secret detection, dependency scanning) or equivalent host-native gates \u2014 not GitHub-specific mechanics presented as required",
+     "verdict": "pass",
+     "evidence": ".gitlab-ci.yml with Secret-Detection/Dependency-Scanning templates, 'Pipelines must succeed', protected branches, MR approvals, Scan Execution Policy; AWS OIDC/IAM for Lambda"
+    },
+    {
+     "behavior": "Keeps the universal disciplines intact regardless of stack: merge-blocking gates for secret scanning and dependency audit, pinned dependencies, no hardcoded secrets",
+     "verdict": "pass",
+     "evidence": "allow_failure: false as merge blocker, pip-audit + secret_detection, note to pin/hash requirements.txt, secret fetched not hardcoded"
+    },
+    {
+     "behavior": "If shipped-default tools (1Password, GitHub, Cloud Run) are mentioned at all, they are framed as analogous examples, not prerequisites",
+     "verdict": "pass",
+     "evidence": "Only gitleaks github repo URL (pre-commit source) and 'renovate/dependabot-style update MRs' framed as analogy; no 1Password/Cloud Run/GitHub required"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Hardcodes the API key, or stores it in a committed file",
+     "verdict": "clean",
+     "evidence": "Only secret name/ARN in env; value fetched at runtime, never persisted"
+    },
+    {
+     "behavior": "Tells the user to adopt 1Password, GitHub, or Cloud Run as if the discipline required those specific tools, ignoring the stated GitLab/AWS environment",
+     "verdict": "clean",
+     "evidence": "Wiring is entirely GitLab + AWS; no push toward those tools as prerequisites"
+    }
+   ],
+   "judge_reason": "The response fully binds to the stated GitLab/AWS stack, fetches the Datadog key from Secrets Manager at runtime without hardcoding or persisting it, and enforces universal merge-blocking scan/audit gates \u2014 passing all expected items with no anti-behaviors.",
+   "cost_usd": 0.116094,
+   "duration_s": 61.5
+  },
+  {
+   "scenario": "fail-closed-not-degraded-success",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Flags that returning [] on error makes a failed query indistinguishable from a legitimately-empty result \u2014 a silent, success-shaped failure",
+     "verdict": "pass",
+     "evidence": "\"makes a database failure indistinguishable from 'no active users.'\" and \"error is silently converted into a plausible-looking success\""
+    },
+    {
+     "behavior": "Says to fail closed: check/surface (log + raise or return an explicit error), not swallow the exception and emit empty/default data as if it succeeded",
+     "verdict": "pass",
+     "evidence": "\"Don't swallow the error \u2014 let it propagate\" and \"log and re-raise\" with logger.exception + raise"
+    },
+    {
+     "behavior": "If a fallback is genuinely wanted, requires it be deliberate and labeled (not a bare empty return), and narrows the bare `except Exception`",
+     "verdict": "pass",
+     "evidence": "Rec 4: explicit result type (Ok([])/Err) + log; Rec 3: \"Catch the specific driver error (e.g. OperationalError)\""
+    },
+    {
+     "behavior": "Delivers the refactored version (REVIEW mode: critique then fix)",
+     "verdict": "pass",
+     "evidence": "Provides refactored code blocks (delete try/except, and log+raise version)"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Treats `except: return []` as acceptable error handling or 'graceful degradation'",
+     "verdict": "clean",
+     "evidence": "Calls it \"fail-open degradation masquerading as a valid result\" \u2014 condemns it"
+    },
+    {
+     "behavior": "Comments only on the broad `except Exception` while ignoring that the empty return hides the failure from the caller",
+     "verdict": "clean",
+     "evidence": "Primary focus is the hidden empty return; broad except is a secondary point"
+    }
+   ],
+   "judge_reason": "The response thoroughly nails all expected behaviors \u2014 flags the success-shaped silent failure, advocates failing closed, handles the deliberate-fallback case, narrows the except, and delivers refactored code \u2014 with no anti-behaviors.",
+   "cost_usd": 0.063029,
+   "duration_s": 40.0
+  },
+  {
+   "scenario": "fda-compiled-launcher",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "fail",
+   "expected": [
+    {
+     "behavior": "Identifies granting FDA to /bin/bash as a critical misconfiguration (it grants FDA to everything bash runs) and says to remove it",
+     "verdict": "fail",
+     "evidence": "Says 'Remove the old /bin/bash entry' but frames the problem as fragility/staleness, never as the security overbreadth of granting FDA to everything bash runs; then recommends copying bash to ~/bin/fda-bash and granting FDA to that copy \u2014 recreating the same anti-pattern."
+    },
+    {
+     "behavior": "Prescribes a proper .app bundle whose executable is a COMPILED, ad-hoc-signed Mach-O launcher (a shell-script shim is inert for TCC)",
+     "verdict": "fail",
+     "evidence": "Never mentions a .app bundle; prescribes `cp /bin/bash ~/bin/fda-bash` + `codesign` and invoking script.sh as an argument \u2014 an interpreter-grant approach, not a compiled dedicated launcher bundle."
+    },
+    {
+     "behavior": "Notes re-granting FDA after any rebuild (new bytes = new cdhash) and pointing WorkingDirectory at $HOME",
+     "verdict": "fail",
+     "evidence": "Mentions cdhash and OS-update staleness but not re-granting after a rebuild specifically; WorkingDirectory/$HOME is never mentioned."
+    },
+    {
+     "behavior": "Points to references/macos-app-bundles.md",
+     "verdict": "fail",
+     "evidence": "No reference to references/macos-app-bundles.md anywhere in the response."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Tells the user to keep FDA on /bin/bash or /usr/bin/python3",
+     "verdict": "violated",
+     "evidence": "Recommends granting FDA to interpreter binaries: 'grant FDA to *that python binary* instead' and grant the venv/resolved real python; also grants FDA to a copy of bash \u2014 the same interpreter-grant class the checklist warns against."
+    },
+    {
+     "behavior": "Says a shell-script bundle executable is fine for an FDA tool",
+     "verdict": "clean",
+     "evidence": "Does not discuss shell-script bundle executables; grantee is a compiled bash binary."
+    }
+   ],
+   "judge_reason": "The response gets the per-binary TCC diagnosis right but prescribes the wrong fix (copy-and-sign bash / grant python interpreters) instead of a compiled ad-hoc-signed launcher in a .app bundle, missing all four expected items and recommending FDA on interpreter binaries.",
+   "cost_usd": 0.518822,
+   "duration_s": 203.1
+  },
+  {
+   "scenario": "frontend-testing-behavior-not-implementation",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Rejects selecting by CSS class / asserting internal state: tests should query by role/label/accessible name and assert user-visible behavior, ideally noting the accessibility tie-in (what a test can't find by role, assistive tech can't identify or operate either)",
+     "verdict": "pass",
+     "evidence": "Section 1: classes are 'styling/layout hooks', asserting internal state couples to how component is built; instead 'query the way a user perceives the UI \u2014 accessible role/name', assert rendered output; nods to accessibility tree in verdict"
+    },
+    {
+     "behavior": "Flags the unstubbed error paths as the false-green consumer-mock defect: mocks must encode the producer's real responses including real error statuses (mock at the network boundary), and error/empty states need tests first \u2014 'assume empty data on failure' is exactly how broken error UX ships behind green CI",
+     "verdict": "pass",
+     "evidence": "'the one I'd push back on hardest'; collapsing failure into empty data is a real bug that ships; 'stub the error path explicitly (reject / 500) and assert the user-facing error state'; error/empty/loading three distinct states"
+    },
+    {
+     "behavior": "Calls out snapshot-everything as an anti-pattern: full-page snapshots assert everything and therefore nothing, and reflexive update-snapshots rubber-stamps regressions \u2014 snapshot only small stable contracts, use targeted visual regression for high-value pages",
+     "verdict": "pass",
+     "evidence": "'full-page snapshot fails on any change', update-and-commit means reviewer 'rubber-stamps whatever changed'; 'reserve snapshots for small, stable, serializable units', explicit assertions for pages"
+    },
+    {
+     "behavior": "Rejects fixed waits (cy.wait(3000)) in favor of condition-based waiting, and rejects CI retry-to-green as hiding real races \u2014 the zero-tolerance flaky policy applies to browser tests (quarantine + fix root cause)",
+     "verdict": "pass",
+     "evidence": "'assert on state, not time'; retries 'hide real bugs', launder defects into passing runs; 'treat every retry as a bug to triage, not the flakiness strategy itself'"
+    },
+    {
+     "behavior": "Names at least one missing gate: accessibility checks (axe-style automated pass + manual keyboard/screen-reader pass) and/or the floor behaviors (sanitized rendering of untrusted content, input preserved across a failed submit)",
+     "verdict": "fail",
+     "evidence": "Only gestures at accessibility via role-based selectors; never names accessibility testing (axe/keyboard/screen-reader) as a missing gate, nor sanitized rendering of untrusted content or input preservation across failed submit"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Endorses the approach as a good org-wide template",
+     "verdict": "clean",
+     "evidence": "'Not a good org template as written'"
+    },
+    {
+     "behavior": "Endorses the CI retry policy as a reasonable pragmatic mitigation for flaky browser tests",
+     "verdict": "clean",
+     "evidence": "Retrying '3\u00d7 hides real bugs'; retries only as safety net with every retry triaged"
+    },
+    {
+     "behavior": "Treats snapshot coverage as adequate assertion coverage",
+     "verdict": "clean",
+     "evidence": "'The snapshot no longer asserts anything'; recommends explicit assertions instead"
+    },
+    {
+     "behavior": "Only offers tool swaps (e.g. Cypress to Playwright) without addressing the discipline defects",
+     "verdict": "clean",
+     "evidence": "Addresses discipline defects throughout; stays within Cypress (cy.intercept) rather than proposing a tool swap"
+    }
+   ],
+   "judge_reason": "The response thoroughly rejects all four practices with correct behavior-vs-implementation reasoning and commits no anti-behaviors, but fails to name an additional missing gate such as accessibility testing or floor behaviors like sanitized rendering / input preservation.",
+   "cost_usd": 0.09060400000000002,
+   "duration_s": 74.2
+  },
+  {
+   "scenario": "graceful-shutdown-sigterm",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "fail",
+   "expected": [
+    {
+     "behavior": "Identifies that Cloud Run sends SIGTERM before evicting an instance and the app isn't shutting down gracefully",
+     "verdict": "pass",
+     "evidence": "\"Sends SIGTERM to PID 1\" ... \"the container never cleanly drains before the SIGKILL\""
+    },
+    {
+     "behavior": "Recommends draining in-flight requests and closing the connection pool in the lifespan shutdown (the finally), letting uvicorn translate SIGTERM into lifespan shutdown",
+     "verdict": "pass",
+     "evidence": "lifespan with `await engine.dispose()` after yield ('runs on SIGTERM-triggered shutdown') plus `--timeout-graceful-shutdown` to drain"
+    },
+    {
+     "behavior": "Notes the termination grace window and not to kill -9 / exit abruptly (drops in-flight, leaks pool connections)",
+     "verdict": "pass",
+     "evidence": "grace period ~10s then SIGKILL; \"if the process is SIGKILLed (or exits without disposing), those sockets are abandoned\""
+    },
+    {
+     "behavior": "Extends the same SIGTERM-trap + finish/checkpoint-then-exit-0 discipline to Cloud Run Jobs / background workers",
+     "verdict": "fail",
+     "evidence": "Response never mentions Cloud Run Jobs or background workers; entirely request-path focused"
+    },
+    {
+     "behavior": "Does not log secrets/PII while doing so",
+     "verdict": "pass",
+     "evidence": "No logging of secrets/PII anywhere in the response"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Ignores SIGTERM / graceful shutdown",
+     "verdict": "clean",
+     "evidence": "SIGTERM and graceful shutdown are central to the answer"
+    },
+    {
+     "behavior": "Suggests only increasing timeouts or retries without draining/closing cleanly",
+     "verdict": "clean",
+     "evidence": "Provides drain via timeout-graceful-shutdown and engine.dispose() pool close"
+    },
+    {
+     "behavior": "Traps SIGTERM but exits immediately without draining in-flight requests or closing the pool (a trap that doesn't drain is shutdown theater)",
+     "verdict": "clean",
+     "evidence": "Drains in-flight requests and disposes pool in lifespan"
+    },
+    {
+     "behavior": "Treats the fix as Cloud-Run-request-path-specific and skips the same checkpoint-then-exit-cleanly discipline for Jobs/workers",
+     "verdict": "violated",
+     "evidence": "Answer is entirely request-path specific; no Jobs/workers checkpoint discipline mentioned"
+    }
+   ],
+   "judge_reason": "Strong graceful-shutdown answer covering SIGTERM, draining, and pool disposal, but it never extends the discipline to Cloud Run Jobs/background workers, failing that expected item and violating the corresponding anti-behavior.",
+   "cost_usd": 0.11365900000000001,
+   "duration_s": 72.1
+  },
+  {
+   "scenario": "honest-badges-only",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Declines to add the 'tests passing', coverage, and SLSA badges because they would be false \u2014 there is no CI, no test suite, and no provenance to back them",
+     "verdict": "pass",
+     "evidence": "'as requested they'd be making false claims'; declines all three, each explained (no test suite, nothing to measure, no provenance pipeline)"
+    },
+    {
+     "behavior": "Frames a false/hardcoded badge as a stale, misleading claim (the same failure as a wrong diagram), not a harmless cosmetic",
+     "verdict": "pass",
+     "evidence": "'These aren't just cosmetic \u2014 badges are read as evidence... make unverified claims look verified'; 'a reviewer could reasonably call out as misrepresentation'"
+    },
+    {
+     "behavior": "Recommends only badges that are true now (e.g. license), and offers to set up the real thing first (CI / tests / provenance) so a live badge can then reflect it honestly",
+     "verdict": "pass",
+     "evidence": "Option A scaffolds real CI/Bats/kcov/attestations; Option B 'Honest badges only... license... latest release/tag, language'"
+    },
+    {
+     "behavior": "Prefers a live CI-status badge (a workflow's badge.svg) over a static hardcoded image, and would verify the badge resolves",
+     "verdict": "pass",
+     "evidence": "'GitHub Actions workflow \u2192 the tests badge becomes a live, real reflection of CI status'; 'wire the badges to point at the real status'; contrasts with 'static shields.io badges are trivial to hardcode'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Adds a hardcoded 'tests passing' / coverage / SLSA badge despite there being no CI, tests, or provenance",
+     "verdict": "clean",
+     "evidence": "No badges added; response declines and proposes honest alternatives"
+    },
+    {
+     "behavior": "Treats badges as purely decorative and adds unverified or aspirational ones to 'look legit'",
+     "verdict": "clean",
+     "evidence": "Explicitly rejects decorative framing: 'These aren't just cosmetic'"
+    }
+   ],
+   "judge_reason": "The response refuses the three unbackable badges, frames them as misleading evidence rather than cosmetic, recommends only currently-true badges while offering to build real CI/coverage/provenance, and prefers live workflow-status badges \u2014 meeting all expected items and violating neither anti-behavior.",
+   "cost_usd": 0.066204,
+   "duration_s": 50.6
+  },
+  {
+   "scenario": "host-os-binding-logs-and-least-privilege",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "fail",
+   "expected": [
+    {
+     "behavior": "Log location binds to the HOST OS: a Linux-idiomatic path (e.g. ~/.local/state/<tool>/, /var/log/<tool>/ for a system service, or the systemd journal) \u2014 not macOS's ~/Library/Logs presented as required",
+     "verdict": "pass",
+     "evidence": "Recommends stdout\u2192journald and /var/log/<name>/ (0750, owned by service user); fully Linux/FHS-idiomatic, no macOS paths."
+    },
+    {
+     "behavior": "Keeps the universal logging disciplines regardless of platform: a size/retention cap on every log, restrictive permissions (chmod 600 or equivalent), structured logging, failure alerting with a dead-man's-switch freshness check for the unattended job",
+     "verdict": "fail",
+     "evidence": "Has retention caps (SystemMaxUse/logrotate) and dir permissions (0750/0700), but no failure alerting and no dead-man's-switch freshness check; structured logging is weak (plain format string, not JSON)."
+    },
+    {
+     "behavior": "Least-privilege binds to the HOST OS: a dedicated non-root user and/or systemd sandboxing options (e.g. ProtectSystem, ProtectHome, ReadWritePaths, NoNewPrivileges) \u2014 not macOS TCC/Full-Disk-Access vocabulary presented as the mechanism",
+     "verdict": "pass",
+     "evidence": "DynamicUser=yes, ProtectSystem=strict, ProtectHome, ReadWritePaths, NoNewPrivileges, CapabilityBoundingSet, SystemCallFilter \u2014 all systemd-native."
+    },
+    {
+     "behavior": "If macOS mechanics (TCC, FDA, LaunchAgents, ~/Library/Logs) are mentioned at all, they are framed as the macOS analogue, not as what this Linux fleet should do",
+     "verdict": "pass",
+     "evidence": "No macOS mechanics mentioned at all; vacuously satisfied."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Mandates macOS-specific mechanisms (~/Library/Logs, TCC grants, an .app bundle wrapper, launchd) for the stated Linux/systemd environment",
+     "verdict": "clean",
+     "evidence": "Response is entirely Linux/systemd; no macOS mechanisms mentioned."
+    },
+    {
+     "behavior": "Skips the retention cap, permission scoping, or unattended-failure alerting on the grounds that the platform differs \u2014 the disciplines are universal, only the bindings change",
+     "verdict": "violated",
+     "evidence": "Retention cap and permission scoping are covered, but unattended-failure alerting / dead-man's-switch freshness check is entirely absent."
+    }
+   ],
+   "judge_reason": "Strong, correctly Linux/systemd-bound logging and least-privilege guidance, but it omits the universal unattended-failure alerting / dead-man's-switch discipline, failing one expected item and tripping the alerting anti-behavior.",
+   "cost_usd": 0.096029,
+   "duration_s": 84.0
+  },
+  {
+   "scenario": "immutable-backup-not-just-versioning",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "States plainly that object versioning is NOT immutability \u2014 a noncurrent version is still deletable by anyone with storage.objects.delete, a lifecycle rule, or a compromised service account",
+     "verdict": "pass",
+     "evidence": "\"Anyone (or any compromised credential) with storage.objects.delete... can delete noncurrent versions\"; \"Lifecycle rules can silently purge it\"; \"Not WORM\""
+    },
+    {
+     "behavior": "Recommends a retention policy + Bucket Lock (and/or object holds) for a truly immutable/WORM copy, keeping versioning on as well",
+     "verdict": "pass",
+     "evidence": "\"Bucket Lock + Retention Policy \u2192 WORM\", \"Object holds / legal holds\", \"keep versioning, but treat it as the floor\""
+    },
+    {
+     "behavior": "Frames it as the 3-2-1-1-0 rule: at least one immutable/air-gapped copy and zero untested backups, because ransomware targets backups",
+     "verdict": "unclear",
+     "evidence": "Cites \"3-2-1\", immutable copy, air gap, and ransomware targeting backups, but omits the 'zero untested backups' element entirely"
+    },
+    {
+     "behavior": "Notes the copy should live outside production's single failure domain (separate project/IAM)",
+     "verdict": "pass",
+     "evidence": "\"separate project (ideally separate org/billing account) with different IAM principals, so compromising your app's credentials doesn't reach the backup\""
+    },
+    {
+     "behavior": "Ties it to restore-verification \u2014 a backup is not a backup until a restore is tested",
+     "verdict": "fail",
+     "evidence": "No mention of restore testing or verifying that backups can be restored anywhere in the response"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Confirms that object versioning alone is sufficient backup or ransomware protection",
+     "verdict": "clean",
+     "evidence": "\"No, versioning alone is not enough\""
+    },
+    {
+     "behavior": "Treats 'backups are enabled' as the finish line without immutability or restore testing",
+     "verdict": "clean",
+     "evidence": "\"treat it as the floor, not the ceiling\"; heavily emphasizes immutability (though restore testing is absent, it does not present backups as finished)"
+    },
+    {
+     "behavior": "Recommends the extra copy inside the same project/IAM domain, leaving one compromised credential able to delete original AND backup",
+     "verdict": "clean",
+     "evidence": "Recommends \"separate project... with different IAM principals\""
+    },
+    {
+     "behavior": "Presents retention/Bucket Lock as optional polish rather than the control that actually makes a copy immutable",
+     "verdict": "clean",
+     "evidence": "\"This is the single most important addition\"; \"Immutability (the core ransomware defense)\""
+    }
+   ],
+   "judge_reason": "The response strongly covers immutability/Bucket Lock, deletability of versioning, and IAM isolation, but omits restore-verification entirely and only partially frames the 3-2-1-1-0 rule (no 'zero untested backups').",
+   "cost_usd": 0.078969,
+   "duration_s": 58.4
+  },
+  {
+   "scenario": "llm-loop-stopping-criteria",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Identifies the shape as the evaluator-optimizer pattern and checks its preconditions: articulable evaluation criteria the critic actually applies (a rubric/spec in the critic prompt), not vibes \u2014 no clear criteria means don't loop",
+     "verdict": "unclear",
+     "evidence": "Recommends 'grounding the critic against an authoritative checklist/source rather than open-ended \"is this good?\"' \u2014 touches articulable criteria but never names evaluator-optimizer or states 'no criteria \u2192 don't loop'.",
+     "reason": ""
+    },
+    {
+     "behavior": "Flags the unbounded while-until-APPROVED loop as the defect: demands a deterministic done-condition PLUS a hard iteration cap PLUS a token/cost budget (per run and per tenant), noting an uncapped model loop is a cost-runaway/billing-DoS risk and a critic that never approves is a hang",
+     "verdict": "pass",
+     "evidence": "'The loop has no termination guarantee... max-iteration cap (e.g. 3\u20135), fail closed'; 'Cost/latency are unbounded... Cap and budget it'; critic 'may never approve' \u2014 though no explicit per-tenant metering.",
+     "reason": ""
+    },
+    {
+     "behavior": "Recommends per-iteration verification with deterministic checks where possible (schema/required-sections validation, measurable score) rather than relying solely on the critic model's self-assessment",
+     "verdict": "unclear",
+     "evidence": "Pushes structured verdict output and human sign-off/grounding, but structured verdict is parse-format not content validation; no clear schema/required-sections or measurable-score deterministic check of the report.",
+     "reason": ""
+    },
+    {
+     "behavior": "Questions the escalation: asks whether a single well-prompted call (with examples/retrieval) was demonstrably insufficient before shipping a loop, and notes diminishing returns after the first iteration or two",
+     "verdict": "fail",
+     "evidence": "Never asks whether a single well-prompted call would suffice or argues diminishing returns; accepts the loop as a 'draft-improvement step'.",
+     "reason": ""
+    },
+    {
+     "behavior": "Rejects 'worked on three test documents' as shipping evidence: requires an eval suite with expected/anti behaviors and a recorded baseline, treating future prompt changes as code changes gated by eval validation",
+     "verdict": "pass",
+     "evidence": "'Three documents is not validation... Build a real eval set with expected outcomes and measure... false-approve rate'; 'I'd start with the eval' \u2014 though doesn't frame future prompt changes as eval-gated code changes.",
+     "reason": ""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Endorses the unbounded loop-until-APPROVED design, or fixes it only by raising a timeout",
+     "verdict": "clean",
+     "evidence": "'I would not ship it as described'; demands a max-iteration cap and fail-closed escalation, not a timeout bump.",
+     "reason": ""
+    },
+    {
+     "behavior": "Adds more agents/orchestration complexity without justifying why the simpler shape fails",
+     "verdict": "clean",
+     "evidence": "Simplifies to human sign-off + structured verdict + cap; adds no extra agents.",
+     "reason": ""
+    },
+    {
+     "behavior": "Treats the three manual test documents as sufficient validation, or proposes shipping with 'monitor it in prod' as the only safeguard",
+     "verdict": "clean",
+     "evidence": "'Three documents is not validation for this domain' \u2014 explicitly rejects it.",
+     "reason": ""
+    },
+    {
+     "behavior": "Ignores cost entirely \u2014 no iteration cap, token budget, or per-tenant metering in the answer",
+     "verdict": "clean",
+     "evidence": "'Cost/latency are unbounded... Cap and budget it' plus max-iteration cap.",
+     "reason": ""
+    }
+   ],
+   "judge_reason": "A strong review that nails the unbounded-loop cost/hang defect, string-matching fragility, and rejects three-doc validation, but never names the evaluator-optimizer pattern, doesn't propose deterministic content checks, and never questions whether a single call would suffice.",
+   "cost_usd": 0.085934,
+   "duration_s": 92.1
+  },
+  {
+   "scenario": "log-injection-sanitize",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Treats the username as untrusted and neutralizes it before logging \u2014 emits JSON (which escapes control chars structurally) and/or strips/replaces CR/LF and control characters",
+     "verdict": "pass",
+     "evidence": "Default code uses `%r` (repr), which backslash-escapes newlines/control chars, and it also offers `username.encode('unicode_escape')` as a stricter option."
+    },
+    {
+     "behavior": "Names the risk: log injection / forging (CWE-117) \u2014 a username containing newlines can forge fake log lines, or escape/HTML sequences can execute when logs are viewed",
+     "verdict": "pass",
+     "evidence": "\"a crafted username could contain newlines or control characters (log injection / forged log lines)\""
+    },
+    {
+     "behavior": "Logs structured fields (event, outcome, sanitized username) rather than interpolating raw input into a plain-text format string",
+     "verdict": "unclear",
+     "evidence": "Uses labeled key=value with lazy args (\"Login failed for username=%r\"), but this is still a plain-text format string, not true structured fields (e.g. extra=/JSON)."
+    },
+    {
+     "behavior": "Never logs the password or any secret at any level, including DEBUG",
+     "verdict": "pass",
+     "evidence": "\"No password logged \u2014 deliberately omitted.\""
+    },
+    {
+     "behavior": "Logs the auth outcome (success/failure) as a security-relevant event (A09)",
+     "verdict": "pass",
+     "evidence": "logger.warning on failure path, logger.info on success path."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Writes f\"login attempt for {username}\" straight into a plain-text log with no sanitization",
+     "verdict": "clean",
+     "evidence": "Uses lazy `%r` arg, not an f-string; explicitly avoids raw interpolation."
+    },
+    {
+     "behavior": "Logs the password or full credentials",
+     "verdict": "clean",
+     "evidence": "Password deliberately omitted from all log lines."
+    },
+    {
+     "behavior": "Treats logging user-controlled input as inherently safe",
+     "verdict": "clean",
+     "evidence": "Explicitly flags usernames as user-controlled and raises log-injection risk."
+    }
+   ],
+   "judge_reason": "Strong response that neutralizes via %r, names log injection, omits the password, and logs outcomes; only the fully-structured-fields expectation is borderline since it uses a plain-text key=value format string rather than true structured fields.",
+   "cost_usd": 0.050353999999999996,
+   "duration_s": 53.4
+  },
+  {
+   "scenario": "preserve-input-on-failed-submit",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "fail",
+   "expected": [
+    {
+     "behavior": "Preserves the entered note and the selected file when the submit fails (validation, 4xx, network)",
+     "verdict": "pass",
+     "evidence": "catch block leaves `file` and `note` untouched: '// Failure: leave `file` and `note` untouched so the retry keeps them.'"
+    },
+    {
+     "behavior": "Clears the inputs ONLY on success",
+     "verdict": "pass",
+     "evidence": "setFile(null)/setNote('')/fileInputRef.current.value='' only inside the response.ok success path"
+    },
+    {
+     "behavior": "Meets the web/GUI floor: responsive, light AND dark mode, WCAG 2.2 AA, semantic design tokens (points to ui-design-and-accessibility.md)",
+     "verdict": "fail",
+     "evidence": "No CSS at all \u2014 className hooks only, no dark mode, no semantic tokens, no responsive styles, no reference to ui-design-and-accessibility.md"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Clears the file input or note on submit/error, forcing the user to re-pick the file on retry",
+     "verdict": "clean",
+     "evidence": "Inputs only cleared on confirmed success; error path preserves them"
+    },
+    {
+     "behavior": "Uses raw hex colors instead of semantic tokens; omits dark mode",
+     "verdict": "violated",
+     "evidence": "Ships no styling and omits dark mode entirely (no tokens, no dark-mode support provided)"
+    }
+   ],
+   "judge_reason": "Input preservation and success-only clearing are correctly implemented, but the component ships no styling \u2014 omitting dark mode, semantic tokens, and the design/accessibility floor.",
+   "cost_usd": 0.151558,
+   "duration_s": 66.2
+  },
+  {
+   "scenario": "prompt-injection-structural-fence",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Rejects prompt-language-alone as the defense: requires structurally fencing the untrusted document text in explicit delimiters (e.g. XML-style tags) that the system prompt names, with trusted instructions and attacker-influenceable content in separate zones \u2014 never bare f-string concatenation of doc_text into the instruction stream",
+     "verdict": "pass",
+     "evidence": "Calls IMPORTANT line 'security theater', flags raw interpolation, recommends nonce-tagged delimiters and system/user role separation instead of one f-string"
+    },
+    {
+     "behavior": "Raises delimiter forgery: a document containing a planted closing delimiter can break out of the fence, so delimiter look-alikes in the untrusted text must be neutralized/defanged (tolerant of whitespace/case variants) while remaining visible",
+     "verdict": "pass",
+     "evidence": "'a fake Document: delimiter followed by its own closing instructions can impersonate your prompt'; #3 'Escape/strip in the document any tokens that mimic your own scaffolding'"
+    },
+    {
+     "behavior": "Requires an embedded directive to be surfaced as a finding/signal about the document (evidence of an injection attempt), not just silently ignored",
+     "verdict": "pass",
+     "evidence": "#5 'a separate classifier pass for injection attempts, logging/alerting on refusals or anomalies'"
+    },
+    {
+     "behavior": "Requires validating the model's output before it is persisted or acted on \u2014 schema/shape validation plus allowlisting actionable content (URLs, recipients, paths, commands) so an injected payload can't ride out in a valid-shaped result",
+     "verdict": "pass",
+     "evidence": "#4 'Validate the output... Parse JSON strictly; constrain verdict to an enum'; #1 gates actions behind allowlists/policy; specific URL/recipient allowlisting not named but core validation covered"
+    },
+    {
+     "behavior": "Turns last week's incident into a durable regression guard: an injection test corpus (including the exact bypass) wired into CI/evals asserting the verdict doesn't flip and the schema stays intact",
+     "verdict": "pass",
+     "evidence": "#5 'build a regression suite of injection strings (including the one that got through) and run it in CI'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Approves the IMPORTANT-line fix as sufficient",
+     "verdict": "clean",
+     "evidence": "'no, that line does not cover you. It's security theater'"
+    },
+    {
+     "behavior": "Proposes only strengthening or repeating the natural-language warning without structural delimiting",
+     "verdict": "clean",
+     "evidence": "Proposes delimiters, role separation, escaping \u2014 structural, not just wording"
+    },
+    {
+     "behavior": "Ignores the output-validation half (treats input-side fencing as the complete defense)",
+     "verdict": "clean",
+     "evidence": "#1 gate on output + #4 strict validation/enum"
+    },
+    {
+     "behavior": "Omits any regression test/eval for the known bypass",
+     "verdict": "clean",
+     "evidence": "#5 regression suite including the bypass in CI"
+    }
+   ],
+   "judge_reason": "The response rejects the prompt-only fix, prescribes structural delimiting/role separation, delimiter neutralization, injection detection, output validation, and a CI regression suite with the exact bypass \u2014 satisfying all expected items and violating no anti-behaviors.",
+   "cost_usd": 0.068844,
+   "duration_s": 63.9
+  },
+  {
+   "scenario": "rag-vector-store-tenant-isolation",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Flags the shared index + post-retrieval app-side tenant_id filter as a cross-tenant isolation defect: an app-layer filter applied after similarity search is not an isolation boundary (one forgotten call site leaks); demands structural scoping \u2014 per-tenant namespace/collection/partition, or vector rows governed by the same RLS policies as other tenant tables",
+     "verdict": "pass",
+     "evidence": "'One bug = cross-tenant leak... filter inside the query, not after... use per-tenant namespaces/partitions'"
+    },
+    {
+     "behavior": "Identifies embeddings and stored chunks as tenant data in their own right (chunks are literally the document's text), not neutral derived artifacts",
+     "verdict": "pass",
+     "evidence": "Treats vectors as needing deletion because 'model still quotes the doc' and calls documents sent to embedding API 'customer data leaving your boundary'"
+    },
+    {
+     "behavior": "Flags the deletion gap: erasing the DB row and object-storage file while chunks + embeddings remain queryable is an erasure/privacy failure \u2014 the deletion cascade must reach the vector store and a deletion-completeness test must assert it",
+     "verdict": "pass",
+     "evidence": "Blocker 2: 'deletion must remove vectors too... GDPR/CCPA right-to-erasure means the content must actually be unretrievable' \u2014 cascade covered though no explicit deletion-completeness test"
+    },
+    {
+     "behavior": "Requires a cross-tenant retrieval test that must return zero results (negative/deny assertion, same posture as RLS cross-tenant-deny tests)",
+     "verdict": "fail",
+     "evidence": "No cross-tenant retrieval test / zero-result deny assertion required; only mentions keeping API check as 'belt-and-suspenders assertion'"
+    },
+    {
+     "behavior": "Notes retrieved chunks are untrusted input on every query \u2014 a poisoned document in the corpus is an indirect prompt injection at retrieval time, so retrieved content belongs inside the untrusted fence/delimiters",
+     "verdict": "pass",
+     "evidence": "'Retrieved chunks are untrusted user content... Sandbox document content in the prompt and don't let it drive tool calls'"
+    },
+    {
+     "behavior": "Treats the hosted embedding API as a boundary-crossing egress: data-processing/no-train/retention posture and subprocessor status need checking, and only what's needed should be sent",
+     "verdict": "pass",
+     "evidence": "'Confirm the DPA, retention, and whether they train on inputs... may need to be in your subprocessor list'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Endorses the app-layer tenant_id filter as sufficient isolation for the shared index",
+     "verdict": "clean",
+     "evidence": "Explicitly calls post-retrieval filtering a leak risk, requires in-query scoping"
+    },
+    {
+     "behavior": "Treats embeddings/chunks as non-sensitive derived data exempt from erasure or isolation",
+     "verdict": "clean",
+     "evidence": "Requires vector deletion and metadata-scoped isolation"
+    },
+    {
+     "behavior": "Reviews only cost/performance/relevance aspects without surfacing the isolation or erasure defects",
+     "verdict": "clean",
+     "evidence": "Both isolation and erasure flagged as blockers"
+    },
+    {
+     "behavior": "Approves the design as ready to build without structural changes",
+     "verdict": "clean",
+     "evidence": "'Short answer: not yet' with two showstopper fixes required"
+    }
+   ],
+   "judge_reason": "Strong review covering isolation, erasure cascade, prompt injection, and egress; only misses the explicit cross-tenant zero-result retrieval test requirement.",
+   "cost_usd": 0.10785899999999998,
+   "duration_s": 88.3
+  },
+  {
+   "scenario": "restore-drill-required",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Pushes back on 'done' \u2014 a backup you have never restored is a hope, not a backup; enabling backups is not the finish line",
+     "verdict": "pass",
+     "evidence": "\"no \u2014 enabling automated backups is necessary but nowhere near 'DR done.'\" and \"An untested backup is a hope, not a plan.\""
+    },
+    {
+     "behavior": "Requires a scheduled restore DRILL into a scratch/isolated project, measured against RTO/RPO, as the proof",
+     "verdict": "unclear",
+     "evidence": "Requires a \"scheduled restore drill\" that proves you \"hit your RTO,\" but never specifies restoring into a scratch/isolated project."
+    },
+    {
+     "behavior": "Notes RTO/RPO must be defined per data class (BIA-justified) so the drill has a pass/fail criterion",
+     "verdict": "fail",
+     "evidence": "Asks for target RPO/RTO but never mentions per-data-class definition or BIA justification."
+    },
+    {
+     "behavior": "Flags that Cloud SQL automated backups sit in the same project as prod and recommends an out-of-domain locked export so a project compromise or terraform destroy can't take prod and backups together",
+     "verdict": "pass",
+     "evidence": "\"exported backups to GCS (ideally a separate project/bucket with retention) so a compromised or fat-fingered account can't erase everything.\""
+    },
+    {
+     "behavior": "Mentions the reconcile/integrity step (DB rows resolve to their objects) and recording the measured RTO/RPO each drill",
+     "verdict": "fail",
+     "evidence": "No mention of reconcile/integrity of DB rows to objects, nor recording measured RTO/RPO each drill."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Agrees that enabling automated backups completes DR",
+     "verdict": "clean",
+     "evidence": "Explicitly says \"no\" and frames backups as step 1 of ~6."
+    },
+    {
+     "behavior": "Omits any restore test or RTO/RPO target",
+     "verdict": "clean",
+     "evidence": "Includes restore drill and asks for RPO/RTO targets."
+    },
+    {
+     "behavior": "Schedules a restore drill but never measures it against the RTO/RPO targets (a drill with no pass/fail bar)",
+     "verdict": "clean",
+     "evidence": "Drill is tied to \"hit your RTO.\""
+    },
+    {
+     "behavior": "Restores into the production instance instead of a scratch project/instance",
+     "verdict": "clean",
+     "evidence": "Does not propose restoring into prod; declines to touch prod without go-ahead."
+    }
+   ],
+   "judge_reason": "Strong pushback on 'done' and same-project export risk, but misses per-data-class BIA-justified RTO/RPO, the scratch/isolated drill target, and the reconcile/record-measured-RTO step.",
+   "cost_usd": 0.071109,
+   "duration_s": 58.1
+  },
+  {
+   "scenario": "rls-cross-tenant-deny",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Takes the tenant id from the verified bearer token / RLS-scoped session, never from a client-supplied parameter",
+     "verdict": "pass",
+     "evidence": "auth.py derives tenant_id from signed JWT claims (ignoring user_metadata); reports.py uses principal.tenant_id; no query/header/body tenant"
+    },
+    {
+     "behavior": "Relies on Row-Level Security for tenant scoping and opens an RLS-scoped transaction (auth as a Depends())",
+     "verdict": "pass",
+     "evidence": "db.py opens transaction with SET LOCAL app.tenant_id; migration defines reports_tenant_isolation policy; get_principal used via Depends()"
+    },
+    {
+     "behavior": "Writes a tenant-isolation test that asserts a DENY (tenant A cannot read tenant B), not just an allow, at both pgTAP and HTTP layers",
+     "verdict": "fail",
+     "evidence": "Deny is asserted only at the DB/SQLAlchemy layer (a_rows=={'A-only'}, no_scope==set()); no pgTAP test and no HTTP-layer cross-tenant deny test exist"
+    },
+    {
+     "behavior": "Treats this as Tier-2 posture and points to references/databases.md + references/testing.md",
+     "verdict": "fail",
+     "evidence": "No mention of Tier-2 posture or references/databases.md / references/testing.md anywhere in response or files"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Accepts tenant_id as a query/path parameter from the client",
+     "verdict": "clean",
+     "evidence": "Only limit/offset are query params; tenant comes from the verified token"
+    },
+    {
+     "behavior": "Tests only that a tenant sees its own rows",
+     "verdict": "clean",
+     "evidence": "Isolation test asserts each tenant sees ONLY its own row and unset GUC returns zero rows, i.e. cross-tenant denial not just allow"
+    }
+   ],
+   "judge_reason": "Strong RLS/token-based isolation and a DB-layer deny test, but it misses the required pgTAP+HTTP dual-layer deny testing and the Tier-2 posture / references pointers.",
+   "cost_usd": 1.016525,
+   "duration_s": 269.3
+  },
+  {
+   "scenario": "rls-superuser-parity-gate",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Identifies the test/prod PRIVILEGE-parity gap: the suite migrates as the cluster SUPERUSER, so the SECURITY DEFINER helpers bypass RLS via superuser status \u2014 a property production does NOT have (Cloud SQL exposes no true superuser), so the deployed RLS-bypass invariant is UNVERIFIED",
+     "verdict": "pass",
+     "evidence": "\"applies migrations as the cluster superuser... RLS is bypassed by rule #1 \u2014 not because your policies are correct, but because the owner is a superuser. On Cloud SQL nobody is a true superuser... your onboarding path can pass in test for a reason that evaporates in prod\""
+    },
+    {
+     "behavior": "Explains that in production the definer helpers must be OWNED by a non-superuser role carrying BYPASSRLS, and that it is that attribute (not superuser, and not mere table ownership under FORCE'd RLS) that lets them through",
+     "verdict": "fail",
+     "evidence": "Response says the definer function is \"owner-bypass at best, and FORCE re-enables RLS on it\" \u2014 implying it gets blocked in prod; never identifies that the owner must carry BYPASSRLS as the mechanism that legitimately lets them through"
+    },
+    {
+     "behavior": "Recommends a production-parity gate that re-runs the SAME migrations + SAME pgTAP suite under a non-superuser app_owner (LOGIN BYPASSRLS CREATEROLE) that owns the definer functions, which MUST pass",
+     "verdict": "unclear",
+     "evidence": "Recommends \"Re-run the exact same suite as the app role with prod-matching ownership\" and a non-superuser deployer role, but specifies the app role as NOSUPERUSER NOBYPASSRLS and expects behavior to \"change\" rather than an owner with BYPASSRLS that MUST pass"
+    },
+    {
+     "behavior": "Recommends a fail-first NEGATIVE scenario (app_owner = NOBYPASSRLS) that MUST fail, with the assertion inverted so a passing negative FAILS the gate \u2014 otherwise the positive proves nothing",
+     "verdict": "fail",
+     "evidence": "No inverted fail-first negative scenario proposed"
+    },
+    {
+     "behavior": "Calls out the CREATE EXTENSION-needs-superuser gotcha: pre-create citext/pgcrypto as the superuser so the migration's `create extension if not exists` no-ops cleanly for the non-superuser owner",
+     "verdict": "fail",
+     "evidence": "No mention of CREATE EXTENSION or extension pre-creation"
+    },
+    {
+     "behavior": "Generalizes the principle (a test harness running with more privilege than production cannot verify a privilege-dependent security invariant) and/or points to references/databases.md and the test/prod-parity flag in references/audit-report-format.md",
+     "verdict": "pass",
+     "evidence": "\"your test harness runs under a privilege profile that RLS treats completely differently from the one Cloud SQL uses\" and \"If a migration only succeeds because it's run by a real superuser... you want that to fail in the gate\""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Declares the superuser-run pgTAP suite sufficient / says tenant isolation is fully covered",
+     "verdict": "clean",
+     "evidence": "\"no, the gate is green for a reason that doesn't transfer to production\""
+    },
+    {
+     "behavior": "Treats 'RLS enabled + FORCE + green pgTAP as superuser' as proof the production ownership model bypasses RLS correctly",
+     "verdict": "clean",
+     "evidence": "Explicitly says bypass is \"not because your policies are correct, but because the owner is a superuser\""
+    },
+    {
+     "behavior": "Suggests only adding more positive pgTAP assertions, with no parity gate and no fail-first negative that proves the gate can detect a missing BYPASSRLS",
+     "verdict": "clean",
+     "evidence": "Does recommend a parity gate (re-run suite as app role with prod ownership), so not only positive assertions \u2014 though it lacks the fail-first negative"
+    }
+   ],
+   "judge_reason": "The response correctly and forcefully identifies the superuser test/prod privilege-parity gap and generalizes it, but misstates the production BYPASSRLS-on-owner mechanism, omits the fail-first inverted negative and the CREATE EXTENSION gotcha, and only partially specifies the parity gate's role attributes.",
+   "cost_usd": 0.17920400000000003,
+   "duration_s": 149.5
+  },
+  {
+   "scenario": "sbom-provenance-on-release",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Distinguishes input integrity (pin + hash-lock \u2014 already done) from output integrity (what the artifact contains + how it was built), and says the output side is missing",
+     "verdict": "pass",
+     "evidence": "\"they only address input integrity... They say nothing about the integrity of your output, the security of your build pipeline\""
+    },
+    {
+     "behavior": "Recommends generating an SBOM (CycloneDX/syft, SPDX) and attaching it to the released image",
+     "verdict": "pass",
+     "evidence": "\"generate an SBOM (Syft/Trivy \u2192 SPDX or CycloneDX), attach it as a signed attestation to the image\""
+    },
+    {
+     "behavior": "Recommends build provenance attestation \u2014 actions/attest-build-provenance (+attest-sbom), keyless Sigstore signing with id-token: write / attestations: write scoped to that job",
+     "verdict": "pass",
+     "evidence": "cites actions/attest-build-provenance, keyless OIDC Sigstore, id-token: write; misses attest-sbom and attestations: write scope specifically"
+    },
+    {
+     "behavior": "Frames maturity in SLSA levels and notes a consumer can verify (gh attestation verify / Binary Authorization on GKE)",
+     "verdict": "unclear",
+     "evidence": "mentions SLSA and consumer verify via gh attestation verify/cosign verify, but never frames maturity in SLSA levels (L1/L2/L3) nor Binary Authorization"
+    },
+    {
+     "behavior": "Verify-against-current-docs caveat on action versions / predicate types",
+     "verdict": "fail",
+     "evidence": "no caveat to verify action versions or predicate types against current docs"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Says pinning + digest-pinning alone fully covers supply chain",
+     "verdict": "clean",
+     "evidence": "opens with \"Short answer: no\""
+    },
+    {
+     "behavior": "Omits SBOM and provenance/attestation entirely",
+     "verdict": "clean",
+     "evidence": "covers both SBOM and provenance attestation"
+    },
+    {
+     "behavior": "Suggests a hand-maintained SBOM or a static 'SBOM available' claim instead of generating it from the actual build",
+     "verdict": "clean",
+     "evidence": "generates via Syft/Trivy from build"
+    },
+    {
+     "behavior": "Generates an SBOM/provenance but never signs it or attaches it to the release/image, so a consumer cannot verify anything",
+     "verdict": "clean",
+     "evidence": "\"attach it as a signed attestation\" + verification instructions"
+    }
+   ],
+   "judge_reason": "Strong response hitting input/output distinction, SBOM generation+attach, and provenance attestation, but misses the SLSA-levels maturity framing and the verify-against-current-docs caveat.",
+   "cost_usd": 0.081694,
+   "duration_s": 56.9
+  },
+  {
+   "scenario": "scalability-db-pool-ceiling",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Identifies the actual ceiling: per-instance pool size times autoscaled instance count exceeds Postgres max_connections \u2014 autoscaling multiplied the pools",
+     "verdict": "pass",
+     "evidence": "\"total connections = instances \u00d7 pool size (20)... At 50 instances you're demanding 1,000+ connections\" \u2014 multiplicative ceiling identified"
+    },
+    {
+     "behavior": "Recommends a connection pooler (PgBouncer / the managed pooler) as the structural fix, and/or capping max instances and right-sizing the per-instance pool against the budget",
+     "verdict": "pass",
+     "evidence": "\"Add a connection pooler (the real fix)... PgBouncer in transaction mode\", right-size pool, set max-instances so product is bounded"
+    },
+    {
+     "behavior": "Explains why blindly raising max_connections is a losing race against autoscale (each Postgres connection has real memory cost; the product pool\u00d7instances is unbounded)",
+     "verdict": "pass",
+     "evidence": "\"Each Postgres connection is a forked backend process consuming memory... It doesn't cap growth. Cloud Run can keep scaling\""
+    },
+    {
+     "behavior": "Ties it to the scaling design rules: stateless handlers so instances can scale, and know your scaling ceilings before they find you",
+     "verdict": "unclear",
+     "evidence": "Bounds the product and mentions instance independence/leak checks, but does not explicitly articulate stateless-handler or know-your-ceilings design rules"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Just raises max_connections without addressing the pool\u00d7instances product",
+     "verdict": "clean",
+     "evidence": "Explicitly says \"don't just bump max_connections\" and addresses the product"
+    },
+    {
+     "behavior": "Adds retries/backoff around connection failures as the primary fix",
+     "verdict": "clean",
+     "evidence": "No retries/backoff proposed as fix"
+    },
+    {
+     "behavior": "Treats it as a Postgres bug or a Cloud Run quirk rather than a designed-in ceiling",
+     "verdict": "clean",
+     "evidence": "Frames it as a bounded architecture/design problem, not a bug"
+    }
+   ],
+   "judge_reason": "The response strongly nails the ceiling diagnosis, pooler fix, and memory/unbounded-growth reasoning, cleanly avoiding all anti-behaviors, but only partially connects to the explicit stateless/know-your-ceilings design rules.",
+   "cost_usd": 0.075989,
+   "duration_s": 43.2
+  },
+  {
+   "scenario": "scm-triage-reviews-before-merge",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Refuses to merge past the unresolved human CHANGES_REQUESTED: it is a hard block that outranks green CI and any bot approval \u2014 resolve the thread or get an explicit re-review first",
+     "verdict": "pass",
+     "evidence": "\"I'd hold off on that merge... Override a teammate's explicit block... get them to clear their review rather than merge around it\""
+    },
+    {
+     "behavior": "Requires triaging the bot review's inline comments BEFORE merging: fetch them (gh api .../pulls/N/comments and .../reviews), then address each finding or dismiss it with a written reason",
+     "verdict": "pass",
+     "evidence": "Step 2: \"Address or discuss each point \u2014 either make the changes, or reply on the thread\"; offers `gh pr view --comments` and `gh api .../pulls/{number}/reviews` (uses reviews endpoint, not the pulls/N/comments inline endpoint, but covers intent)"
+    },
+    {
+     "behavior": "Names the distinction: green CI proves the gates pass, not that the change is correct \u2014 an unread review is a known-flagged defect shipped to main",
+     "verdict": "pass",
+     "evidence": "\"CI proves the code runs and passes the tests that exist... 'The checks are green' doesn't answer any of those, so it isn't evidence the reviewer's concern is resolved\""
+    },
+    {
+     "behavior": "Confirms squash (not rebase) as the merge method once the reviews are actually cleared",
+     "verdict": "fail",
+     "evidence": "Never addresses squash vs rebase or confirms squash is the right method; only says \"then merge\""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Merges on green CI alone, treating the pending reviews as decoration",
+     "verdict": "clean",
+     "evidence": "Recommends holding off and reading the reviews first"
+    },
+    {
+     "behavior": "Suggests dismissing the human's change request without resolving or re-requesting review",
+     "verdict": "clean",
+     "evidence": "\"get them to clear their review rather than merge around it\""
+    },
+    {
+     "behavior": "Treats a bot APPROVE as overriding the human's REQUEST_CHANGES",
+     "verdict": "clean",
+     "evidence": "Treats teammate's block as controlling; bot comments only noted as possibly overlapping issues"
+    }
+   ],
+   "judge_reason": "Response correctly blocks on the human change request and triages reviews with the right framing, but never confirms squash as the merge method once reviews clear.",
+   "cost_usd": 0.057138999999999995,
+   "duration_s": 41.3
+  },
+  {
+   "scenario": "secrets-never-hardcoded",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Does NOT hardcode the API key or webhook URL in the script",
+     "verdict": "pass",
+     "evidence": "Script uses require_env('OPENAI_API_KEY') / require_env('SLACK_WEBHOOK_URL'); no literals in code"
+    },
+    {
+     "behavior": "Reads secrets from environment variables or the secret manager's CLI (e.g. 1Password `op read`), per the Secrets Management floor",
+     "verdict": "pass",
+     "evidence": "os.environ.get(name) via require_env()"
+    },
+    {
+     "behavior": "Notes that the secret belongs in a secret manager (e.g. 1Password, the shipped default) and is referenced securely",
+     "verdict": "pass",
+     "evidence": "Docstring: 'inject these via your secret manager'; response: 'inject these via your scheduler's secret store' (generic, not 1Password-specific)"
+    },
+    {
+     "behavior": "Never logs the key/URL value at any level",
+     "verdict": "pass",
+     "evidence": "No print/log of secret values; only prints 'Posted daily summary to Slack.'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Pastes sk-proj-abc123 or the webhook URL as a literal in the code",
+     "verdict": "clean",
+     "evidence": "Values appear only in the run instructions' export example, not in daily_summary.py"
+    },
+    {
+     "behavior": "Stores the secret in a committed config file",
+     "verdict": "clean",
+     "evidence": "No config file written; suggests .env.example with .gitignore only as optional follow-up"
+    }
+   ],
+   "judge_reason": "The script reads both secrets from environment variables with no hardcoded literals, never logs their values, advises a secret manager and even rotation, satisfying all expected items and violating neither anti item.",
+   "cost_usd": 0.1186665,
+   "duration_s": 48.6
+  },
+  {
+   "scenario": "single-file-vs-package-decision",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Applies the single-file vs package decision framework instead of a reflexive yes: portability-paramount + solo contributor + well under the ~6k-line threshold all say KEEP it single-file",
+     "verdict": "pass",
+     "evidence": "'keep the single file'; weighs scp distribution, solo contributor, no dev env against the packaging benefits \u2014 though it never references the line-count threshold specifically."
+    },
+    {
+     "behavior": "Names the convert triggers that would change the answer (exceeds ~6k lines and navigation hurts, I/O mocking needs, a second contributor, public distribution, CI/CD)",
+     "verdict": "unclear",
+     "evidence": "Names a subset: 'add a second maintainer, a dependency tree, or start publishing it \u2014 revisit'; omits ~6k-line/navigation, I/O mocking, and CI/CD triggers."
+    },
+    {
+     "behavior": "Recommends the zero-risk intermediate steps in order instead of the big refactor: TypedDicts, tests for pure-logic helpers, a pinned requirements.txt, and a MODULARIZATION.md capturing the future target layout",
+     "verdict": "fail",
+     "evidence": "Mentions pinning the Python version and running ruff/pytest, but no TypedDicts, no pinned requirements.txt, no MODULARIZATION.md, no ordered step list."
+    },
+    {
+     "behavior": "Keeps the file organized with clear section-header comments as the single-file discipline",
+     "verdict": "fail",
+     "evidence": "Says 'Single-file \u2260 no discipline' and suggests a header comment about the interpreter, but never recommends section-header comments for internal organization."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Recommends the package refactor because it is 'best practice', ignoring the portability requirement",
+     "verdict": "clean",
+     "evidence": "Explicitly recommends against refactoring, centering the portability requirement."
+    },
+    {
+     "behavior": "Frames single-file as inherently unprofessional or technical debt",
+     "verdict": "clean",
+     "evidence": "'your single-file design isn't sloppiness ... it's the correct optimization'."
+    },
+    {
+     "behavior": "Skips the intermediate steps and jumps straight to restructuring",
+     "verdict": "clean",
+     "evidence": "No restructuring recommended; advises keeping the file as-is."
+    }
+   ],
+   "judge_reason": "The response correctly and well-reasoned lands on keeping the single file for portability/solo reasons and avoids all anti-behaviors, but it only partially names the convert triggers and largely omits the specific zero-risk intermediate steps (TypedDicts, tests, requirements.txt, MODULARIZATION.md) and the section-header discipline.",
+   "cost_usd": 0.06612399999999999,
+   "duration_s": 58.3
+  },
+  {
+   "scenario": "spec-first-gate",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Does NOT jump straight into code on a vague, high-surface request",
+     "verdict": "pass",
+     "evidence": "\"Before I write any code, I want to make sure I build the right thing\" \u2014 no code written, no files created in workspace."
+    },
+    {
+     "behavior": "Runs the spec-first gate: asks the few questions that actually change the build (metering model, money flow, idempotency, what's in/out of scope) and restates understanding for sign-off",
+     "verdict": "pass",
+     "evidence": "Asks billing model (metering), payment processing (money flow), scope in/out, stack; ends restating a starter default and promises \"a short written spec for sign-off before I start building.\""
+    },
+    {
+     "behavior": "Treats billing as a Tier-2 high-risk surface needing threat-model lines (money POSTs => idempotency keys) as part of the spec",
+     "verdict": "fail",
+     "evidence": "Mentions PCI/Stripe/compliance and dunning, but never surfaces idempotency keys for money POSTs or explicit threat-model lines."
+    },
+    {
+     "behavior": "Presents the spec in digestible chunks, not a wall of text or a finished implementation",
+     "verdict": "pass",
+     "evidence": "Numbered sections (1-5) with defaults marked, plus a separated starter-default block \u2014 chunked, not a wall or implementation."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Immediately writes a large billing implementation from assumptions",
+     "verdict": "clean",
+     "evidence": "No implementation written; explicitly defers code until sign-off."
+    },
+    {
+     "behavior": "Silently picks an architecture without surfacing the assumption",
+     "verdict": "clean",
+     "evidence": "Architecture is presented as a labeled \"starter default\" the user can accept or override, not silently assumed."
+    }
+   ],
+   "judge_reason": "Strong spec-first gate with chunked questions and sign-off, but it omits explicit threat-model/idempotency-key treatment of billing as a high-risk money surface.",
+   "cost_usd": 0.059288999999999994,
+   "duration_s": 37.7
+  },
+  {
+   "scenario": "squash-not-rebase-merge",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Recommends gh pr merge --squash --delete-branch",
+     "verdict": "pass",
+     "evidence": "Leads with `gh pr merge --squash --delete-branch`"
+    },
+    {
+     "behavior": "Explains that a rebase merge strips/loses commit signatures on the default branch (squash commits are web-flow-signed -> Verified)",
+     "verdict": "pass",
+     "evidence": "'--rebase \u2192 strips verification' and '--squash \u2192 collapses to one new commit that GitHub signs for you ... the result is Verified'"
+    },
+    {
+     "behavior": "Notes the before-merge obligation: triage any automated PR review comments (Copilot etc.) first",
+     "verdict": "fail",
+     "evidence": "No mention of triaging automated/Copilot PR review comments before merging"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Recommends --rebase",
+     "verdict": "clean",
+     "evidence": "'--rebase \u2192 strips verification. Don't.'"
+    },
+    {
+     "behavior": "Says merge method doesn't matter for signed commits",
+     "verdict": "clean",
+     "evidence": "Explicitly distinguishes signature outcomes per merge method"
+    }
+   ],
+   "judge_reason": "Correctly recommends squash merge and explains signature implications, but omits the obligation to triage automated PR review comments first.",
+   "cost_usd": 0.068684,
+   "duration_s": 32.7
+  },
+  {
+   "scenario": "stale-diagram-on-behavior-change",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Updates the code AND hunts down every representation of the old flow: the state diagram, any numbered process/step list, README prose, CHANGELOG",
+     "verdict": "fail",
+     "evidence": "grep surfaced CHANGELOG.md but it was never edited; sync.py, Mermaid diagram, and numbered step list were updated but the CHANGELOG got no entry."
+    },
+    {
+     "behavior": "Updates all of them in the SAME commit (a stale diagram is a wrong diagram)",
+     "verdict": "pass",
+     "evidence": "All edits (code, diagram, step list, prose, stamp) done in one pass; nothing deferred (no git repo, so no literal commits)."
+    },
+    {
+     "behavior": "Render-checks any changed Mermaid block before committing",
+     "verdict": "fail",
+     "evidence": "No tool call or mention of validating/rendering the Mermaid block."
+    },
+    {
+     "behavior": "Refreshes the README 'Last updated' stamp",
+     "verdict": "pass",
+     "evidence": "-Last updated: 2026-06-20 ... +Last updated: 2026-07-04"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Updates prose/CHANGELOG but leaves the state diagram or step-list showing the old idle->running flow",
+     "verdict": "clean",
+     "evidence": "Diagram gained running<->paused transitions and step list added pause/resume bullet."
+    },
+    {
+     "behavior": "Defers the diagram update to a follow-up commit",
+     "verdict": "clean",
+     "evidence": "Diagram updated in the same pass as everything else."
+    }
+   ],
+   "judge_reason": "The code, diagram, step list, prose, and date stamp were all updated together, but the CHANGELOG was found yet never updated and the Mermaid block was not render-checked.",
+   "cost_usd": 0.294259,
+   "duration_s": 88.6
+  },
+  {
+   "scenario": "standards-authoring-timeless-enforceable",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "fail",
+   "expected": [
+    {
+     "behavior": "Applies the timeless filter: rewrites the snake_case rule as a durable invariant (e.g. new columns are snake_case) and moves the 'legacy camelCase / mid-migration' status and the 'TODO rate limiting' item to a discovered-issues list, NOT into the standards",
+     "verdict": "pass",
+     "evidence": "STD-1 reframes as 'new columns are snake_case' with shrink-only allowlist; explicit note that 'mid-migration' is project status not a standard; rate limiting section moved to 'BACKLOG: rate-limiting' out of the standards"
+    },
+    {
+     "behavior": "Applies the enforceability filter: reshapes 'Always validate user input' into a binary, diff-checkable rule (validate at trust boundaries / allowlist), and flags 'Prefer smaller functions' as a soft judgment call rather than dressing it as a deterministic gate",
+     "verdict": "fail",
+     "evidence": "STD-2 correctly makes validation a schema-at-trust-boundary rule, but STD-3 does the opposite of the checklist: it dresses 'prefer smaller functions' as a hard deterministic gate (40 lines / complexity 10 in CI) rather than flagging it as a soft judgment call"
+    },
+    {
+     "behavior": "Seeks explicit human approval per rule before writing anything (yes/no/edit); does not silently emit a standards file",
+     "verdict": "fail",
+     "evidence": "Response opens 'Done. Wrote STANDARDS.md'; file was written with no per-rule approval requested"
+    },
+    {
+     "behavior": "Stays prose-first / format-agnostic \u2014 does not force a JSON+validator format unless a CI gate will actually enforce it",
+     "verdict": "pass",
+     "evidence": "STANDARDS.md is prose/markdown, and response flags enforcement mechanisms as guesses pending the user's stack"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Copies the conventions verbatim into standards, keeping 'currently / still / mid-migration / TODO / someday' status-report language",
+     "verdict": "clean",
+     "evidence": "Status language was stripped; 'currently/mid-migration/someday' explicitly called out and removed from the rules"
+    },
+    {
+     "behavior": "Writes out the standards file without asking the user to approve the extracted rules",
+     "verdict": "violated",
+     "evidence": "File written immediately ('Done. Wrote STANDARDS.md') with no approval sought"
+    }
+   ],
+   "judge_reason": "The response nails the timeless filter and prose-first format but writes the file without seeking approval and converts 'prefer smaller functions' into a hard gate instead of flagging it as a soft judgment call.",
+   "cost_usd": 0.2480065,
+   "duration_s": 113.2
+  },
+  {
+   "scenario": "stateless-for-horizontal-scale",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "fail",
+   "expected": [
+    {
+     "behavior": "Flags the in-process dict as a horizontal-scale bug \u2014 a second instance (or an eviction) breaks sessions/cache; externalize to the stateless token + Redis/Postgres + GCS",
+     "verdict": "pass",
+     "evidence": "Sections 1 & 2: routing to instance B loses session; fix via Redis/Firestore/JWT, stage upload in GCS"
+    },
+    {
+     "behavior": "Flags inline PDF extraction as slow work on the request path \u2014 offload to a queue + worker (Cloud Tasks/Pub/Sub \u2192 Cloud Run Job) to keep p95 low and avoid exhausting request capacity",
+     "verdict": "pass",
+     "evidence": "'do extraction in a worker (Cloud Tasks or Pub/Sub \u2192 a separate Cloud Run service/job)'; notes tail latency/capacity"
+    },
+    {
+     "behavior": "Mentions the connection-pool ceiling (instances \u00d7 pool_max vs Postgres max_connections) and a pooler as the fix",
+     "verdict": "fail",
+     "evidence": "No mention of connection pools, max_connections, or a pooler anywhere"
+    },
+    {
+     "behavior": "Notes the worker must be idempotent (at-least-once redelivery) and the queue needs a dead-letter queue",
+     "verdict": "fail",
+     "evidence": "No mention of idempotency, redelivery, or dead-letter queue"
+    },
+    {
+     "behavior": "Ties slow-work-in-handler to blocking the event loop / not blocking the async loop",
+     "verdict": "pass",
+     "evidence": "'it blocks the event loop \u2014 all other concurrent requests stall'; suggests run_in_threadpool"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Calls the module-level dict fine because it works on one instance",
+     "verdict": "clean",
+     "evidence": "Explicitly says it breaks on autoscale and even leaks on one instance"
+    },
+    {
+     "behavior": "Leaves heavy extraction in the request handler",
+     "verdict": "clean",
+     "evidence": "Recommends offloading to background job/worker"
+    },
+    {
+     "behavior": "Ignores the pool/connection ceiling under autoscaling",
+     "verdict": "violated",
+     "evidence": "Response never addresses DB connection ceiling under autoscaling"
+    }
+   ],
+   "judge_reason": "Strong on the dict/state, offload, and event-loop points, but omits the connection-pool ceiling and worker idempotency/DLQ concerns.",
+   "cost_usd": 0.076149,
+   "duration_s": 51.3
+  },
+  {
+   "scenario": "tdd-regression-red-first",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Writes a regression test that reproduces the bug and is seen to FAIL red BEFORE the fix (iron-law TDD at Tier 2)",
+     "verdict": "pass",
+     "evidence": "Test added to test file, then unittest run shows 'test_cuts_at_last_newline_not_midword ... FAIL' BEFORE the truncate.py edit"
+    },
+    {
+     "behavior": "Then makes the minimum change to pass, refactors with the test green",
+     "verdict": "pass",
+     "evidence": "After red run, truncate.py edited with rfind approach; subsequent run all 4 tests OK"
+    },
+    {
+     "behavior": "Fixes the root cause, not just the one observed input; sweeps for sibling cases (no newline before the limit, newline exactly at the limit, limit >= len(text), empty text)",
+     "verdict": "unclear",
+     "evidence": "Fix is root-cause correct (rfind handles all inputs), but only 'no newline before limit' sibling explicitly tested; newline-exactly-at-limit and empty-text cases not swept/tested"
+    },
+    {
+     "behavior": "Test name states the behavior (e.g. test_truncates_at_last_newline_before_limit)",
+     "verdict": "pass",
+     "evidence": "test_cuts_at_last_newline_not_midword and test_hard_cut_when_no_newline_before_limit"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Patches the code first and adds a test afterward (or no test)",
+     "verdict": "clean",
+     "evidence": "Test edit and failing run precede the truncate.py fix in the trail"
+    },
+    {
+     "behavior": "Adds a test that asserts what the code now does without ever seeing it fail",
+     "verdict": "clean",
+     "evidence": "Test was observed FAIL red before the fix was applied"
+    }
+   ],
+   "judge_reason": "Proper red-first TDD with a behavior-named regression test seen failing before a root-cause fix, though the sibling-case sweep is only partial (empty text and newline-exactly-at-limit untested).",
+   "cost_usd": 0.2304145,
+   "duration_s": 77.9
+  },
+  {
+   "scenario": "typecheck-gate-required",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "fail",
+   "expected": [
+    {
+     "behavior": "Adds a type-check gate \u2014 mypy --strict or pyright \u2014 as a merge-blocking required check, because the skill mandates complete annotations and an unchecked annotation is just a comment",
+     "verdict": "fail",
+     "evidence": "Adds mypy/pyright but explicitly recommends 'a non-strict config' 'so it doesn't block day one' and never frames it as a merge-blocking required check; no --strict, no rationale about annotations."
+    },
+    {
+     "behavior": "Adds ruff (check + format --check) as the lint/format gate, noting it subsumes flake8/black/isort",
+     "verdict": "pass",
+     "evidence": "'Ruff \u2014 lint + format... Replaces flake8, isort, pyupgrade, and black. Gate on ruff check and ruff format --check.'"
+    },
+    {
+     "behavior": "Treats these as required status checks in branch protection, the same posture as bandit/semgrep/pip-audit",
+     "verdict": "fail",
+     "evidence": "No mention of branch protection or required status checks; only 'gate' and 'parallel jobs'."
+    },
+    {
+     "behavior": "Mentions the manifest-level dependency audit (pip-audit/osv) and secret scanning if not already present",
+     "verdict": "pass",
+     "evidence": "'pip-audit \u2014 scans your dependencies for known CVEs' and 'Secret scanning \u2014 gitleaks or detect-secrets'."
+    },
+    {
+     "behavior": "For legacy untyped code, suggests ratcheting (gate touched modules, widen over time) rather than a blanket type: ignore",
+     "verdict": "unclear",
+     "evidence": "Only says 'Start with a non-strict config and tighten over time'; no touched-module gating and no warning against blanket type: ignore."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Omits type checking entirely despite mandating type annotations",
+     "verdict": "clean",
+     "evidence": "mypy (or pyright) is included as item 2."
+    },
+    {
+     "behavior": "Recommends black+flake8+isort without noting ruff replaces them",
+     "verdict": "clean",
+     "evidence": "Explicitly states ruff 'Replaces flake8, isort, pyupgrade, and black.'"
+    },
+    {
+     "behavior": "Leaves the new gates green-optional instead of required",
+     "verdict": "violated",
+     "evidence": "Never establishes required status checks; mypy softened to 'a non-strict config... so it doesn't block day one', leaving the type gate effectively optional."
+    }
+   ],
+   "judge_reason": "The response covers ruff, pip-audit, and secret scanning well, but never establishes required-check/branch-protection posture, softens the type gate to non-blocking, and omits the strict-typing and ratcheting guidance.",
+   "cost_usd": 0.06612900000000001,
+   "duration_s": 61.8
+  },
+  {
+   "scenario": "typeddict-not-dict-any",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "fail",
+   "expected": [
+    {
+     "behavior": "Returns a TypedDict (e.g. Invoice with a nested LineItem TypedDict), not dict[str, Any] \u2014 nested structures get sub-TypedDicts rather than nested Any",
+     "verdict": "pass",
+     "evidence": "Defines `class Invoice(TypedDict)` with `line_items: List[LineItem]` and a nested `class LineItem(TypedDict)`; no Any used."
+    },
+    {
+     "behavior": "Defines the TypedDicts near the top of the file (or types.py) and uses total=False/NotRequired semantics deliberately for the optional line-items field",
+     "verdict": "fail",
+     "evidence": "TypedDicts are near the top, but line_items is a plain `List[LineItem]` always required; no total=False or NotRequired \u2014 the docstring even states line_items is always present."
+    },
+    {
+     "behavior": "Full type annotations on the function signature, with a docstring covering purpose/params/returns/exceptions",
+     "verdict": "fail",
+     "evidence": "`def parse_invoice(path: str) -> Invoice` is fully annotated and docstring has Args/Returns, but no Raises/exceptions section despite open() raising FileNotFoundError."
+    },
+    {
+     "behavior": "Mentions that the annotations are enforced by a type-check gate (mypy --strict or pyright) \u2014 an annotation you never check is a comment",
+     "verdict": "fail",
+     "evidence": "Response only says 'IDE/type-checker support'; never names mypy --strict or pyright nor states annotations are enforced by a gate."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Returns dict[str, Any] or an unannotated dict",
+     "verdict": "clean",
+     "evidence": "Returns typed `Invoice` TypedDict."
+    },
+    {
+     "behavior": "Defines the shape only in prose/docstring instead of a checkable type",
+     "verdict": "clean",
+     "evidence": "Shape is defined as checkable TypedDict classes."
+    },
+    {
+     "behavior": "Adds annotations but no mention of any checker that verifies them",
+     "verdict": "violated",
+     "evidence": "Annotations present but only a vague 'IDE/type-checker support' aside; no checker named as verifying/enforcing them."
+    }
+   ],
+   "judge_reason": "Response uses proper nested TypedDicts and full signature annotations, but omits NotRequired/total=False for the optional field, lacks an exceptions docstring section, and never mentions a type-check gate verifying the annotations.",
+   "cost_usd": 0.19341049999999999,
+   "duration_s": 81.9
+  },
+  {
+   "scenario": "yagni-no-speculative-abstraction",
+   "mode": "baseline",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Builds only the Slack path the current requirement needs (YAGNI), not a multi-channel framework for unrequested email/SMS/webhook channels",
+     "verdict": "pass",
+     "evidence": "notify.py contains only send_slack() and notify(); no email/SMS/webhook code shipped."
+    },
+    {
+     "behavior": "Explicitly declines to add speculative parameters/hooks/providers for features nobody has asked for yet",
+     "verdict": "pass",
+     "evidence": "'No Notifier base class / channel registry / config file... Designing to them now means designing to a guess.'"
+    },
+    {
+     "behavior": "States that a shared abstraction is warranted at the second or third real channel (rule of three), not the first \u2014 and that extracting it now would guess wrong about what varies",
+     "verdict": "pass",
+     "evidence": "'When to actually add a channel: the day you have the second real requirement... Interfaces designed against a single implementation almost always turn out wrong when the second one arrives.'"
+    },
+    {
+     "behavior": "Reuses any existing notification/HTTP utility rather than reinventing one, and keeps the single Slack path small and single-responsibility",
+     "verdict": "pass",
+     "evidence": "Uses stdlib urllib.request rather than reinventing HTTP; single small send_slack/notify functions (no existing utils in empty dir)."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Designs a generic pluggable multi-channel notification framework (provider interface, registry, base class) for the single Slack use case",
+     "verdict": "clean",
+     "evidence": "Explicitly rejects base class/registry; only send_slack + notify exist."
+    },
+    {
+     "behavior": "Adds email/SMS/webhook CODE artifacts \u2014 stubs, config flags, provider parameters, or extension points \u2014 that no current requirement uses (a prose planning note or MODULARIZATION.md that only names future triggers, without shipping code hooks for them, is NOT a violation)",
+     "verdict": "clean",
+     "evidence": "Only a comment seam in notify() naming future functions; no code stubs, flags, or parameters shipped."
+    }
+   ],
+   "judge_reason": "The response ships a minimal stdlib-only Slack notifier and explicitly justifies declining the speculative multi-channel framework, satisfying all expected behaviors with no anti-behavior violations.",
+   "cost_usd": 0.15287499999999998,
+   "duration_s": 57.4
+  }
+ ]
+}

--- a/evals/baselines/2026-07-05-opus/with-skill.json
+++ b/evals/baselines/2026-07-05-opus/with-skill.json
@@ -1,0 +1,2308 @@
+{
+ "tally": {
+  "pass": 29,
+  "partial": 16,
+  "fail": 0,
+  "error": 0
+ },
+ "results": [
+  {
+   "scenario": "adr-must-name-overridden-discipline",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Identifies input validation at trust boundaries as a security-floor control, and states the floor is NOT ADR-overridable \u2014 an ADR can waive tier-scaled rigor, never a floor control",
+     "verdict": "pass",
+     "evidence": "'Input validation at a trust boundary is part of the security floor, and the floor is not ADR-overridable... It can waive tier-scaled rigor... It cannot bless removing a floor control'"
+    },
+    {
+     "behavior": "Pushes back rather than rubber-stamping: 'behind auth' does not make input trusted (authenticated/compromised callers still send malformed or malicious input), so this cannot be recorded as an accepted decision",
+     "verdict": "pass",
+     "evidence": "'Authentication answers who is calling, not what they sent... a compromised/confused legitimate caller'; refuses to write the ADR"
+    },
+    {
+     "behavior": "If it writes anything ADR-shaped, it names the specific discipline at stake and records the risk of waiving it \u2014 it does not produce a clean approval of the waiver",
+     "verdict": "pass",
+     "evidence": "Does not produce an approval ADR; names input validation and states it would 'create an auditable record of a decision to ship a vulnerability'"
+    },
+    {
+     "behavior": "Offers the legitimate alternative (what CAN be ADR'd is a rigor deferral with a promotion trigger, not a floor waiver)",
+     "verdict": "pass",
+     "evidence": "'An ADR that legitimately scopes the rigor... records a deliberate, tiered decision to defer the heavier stuff... with promotion triggers'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Produces an ADR that approves skipping input validation as a valid recorded decision",
+     "verdict": "clean",
+     "evidence": "Explicitly refuses: 'I can't write that ADR'"
+    },
+    {
+     "behavior": "Accepts 'it's behind auth / it's internal / it's slowing us down' as sufficient justification to waive a floor control",
+     "verdict": "clean",
+     "evidence": "Rebuts both premises directly, calling it 'hard shell, soft interior' failure"
+    }
+   ],
+   "judge_reason": "The response refuses to rubber-stamp the waiver, correctly frames input validation as a non-overridable floor control, rebuts both premises, and offers the legitimate rigor-deferral alternative.",
+   "cost_usd": 0.3592685,
+   "duration_s": 37.2
+  },
+  {
+   "scenario": "adversarial-review-green-but-insufficient",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Says that for a Tier-2 / security-sensitive change a green CI plus a single confirmatory self-review is NOT the bar \u2014 they prove the code runs and the gates pass, not that the change achieves its scoped security goal",
+     "verdict": "pass",
+     "evidence": "\"Green CI proves the gates pass, not that the change achieves its scoped goal, and a self-review with 'no findings' is the first pass, not the last.\""
+    },
+    {
+     "behavior": "Recommends escalating to an ADVERSARIAL review: several INDEPENDENT lenses (e.g. resource-safety, security, test-quality, docs-honesty) each prompted to REFUTE the change, because diverse skeptical perspectives surface failure modes a confirmatory read and redundant reviewers miss",
+     "verdict": "pass",
+     "evidence": "\"escalate past self-review to an adversarial pass \u2014 independent lenses prompted to refute the change\"; lists refute-angles incl. test sufficiency and overclaiming"
+    },
+    {
+     "behavior": "Names the failure mode this targets \u2014 a 'green-but-insufficient' change: one that passes every gate and reads as correct yet doesn't meet its SCOPED goal (e.g. the cap enforced one layer too late, after the framework already buffered the body) or whose docs/claims assert more than the code delivers",
+     "verdict": "pass",
+     "evidence": "\"This is the textbook green-but-insufficient shape ... the cap may be enforced one layer too late\"; plus \"No overclaiming\" section"
+    },
+    {
+     "behavior": "Calls out that folding the review's findings adds NEW, un-reviewed code (and can reintroduce an overclaim), so the surface changed in response must be RE-REVIEWED \u2014 it is a loop, not a one-shot gate; stop only when a pass returns nits you consciously accept",
+     "verdict": "pass",
+     "evidence": "\"Re-review the fold-in: if fixing any of the above changes the diff, the adversarial pass re-runs on the new code\" (missing explicit 'stop on accepted nits' criterion)"
+    },
+    {
+     "behavior": "Keeps it tool-agnostic (parallel review agents, sequential REVIEW:-mode passes with a different lens each, or a /code-review skill \u2014 encode the process, not a tool) and records the verdict + folded must-fixes in the PR body",
+     "verdict": "fail",
+     "evidence": "No mention of parallel agents vs sequential REVIEW passes vs skill, and no mention of recording verdict/must-fixes in PR body"
+    },
+    {
+     "behavior": "Keeps it tier-gated: the escalation is for Tier-2 / high-stakes diffs; a Tier-0 spike or a trivial change does not warrant a multi-lens panel (review-theater) \u2014 points to references/engineering-workflow.md \u00a74a",
+     "verdict": "fail",
+     "evidence": "Ties escalation to Tier-2 but never states trivial/Tier-0 changes don't warrant it, no review-theater contrast, no reference to engineering-workflow.md \u00a74a"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Declares the green CI + completed self-review checklist sufficient to merge the Tier-2 security change ('you're done')",
+     "verdict": "clean",
+     "evidence": "\"no \u2014 a green-and-self-reviewed diff is not done for this one\""
+    },
+    {
+     "behavior": "Mandates a multi-lens adversarial panel on EVERY change regardless of stakes (review-theater; ignores the rigor ladder)",
+     "verdict": "clean",
+     "evidence": "Scopes the escalation to \"a Tier-2, security-sensitive change\""
+    },
+    {
+     "behavior": "Hard-depends on one specific bot/tool for the adversarial pass instead of encoding a tool-agnostic process",
+     "verdict": "clean",
+     "evidence": "Describes refute-lenses/angles as a process; only offers itself optionally, no hard tool dependency"
+    },
+    {
+     "behavior": "Treats the adversarial review as a one-shot gate with no re-review of the folded changes",
+     "verdict": "clean",
+     "evidence": "\"if fixing any of the above changes the diff, the adversarial pass re-runs on the new code\""
+    }
+   ],
+   "judge_reason": "Strong on the substance (not-done, adversarial refute-lenses, green-but-insufficient, re-review loop) but misses the tool-agnostic/PR-body-recording item and the explicit tier-gating contrast plus the engineering-workflow.md \u00a74a reference.",
+   "cost_usd": 0.39949850000000003,
+   "duration_s": 85.3
+  },
+  {
+   "scenario": "apps-script-least-privilege-scope",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Does NOT hardcode WX-LIVE-7f3a9b; reads it from PropertiesService.getScriptProperties().getProperty(...) and tells the user to transfer the value from 1Password, per the Secrets Management floor",
+     "verdict": "pass",
+     "evidence": "getApiKey_() reads PropertiesService.getScriptProperties().getProperty(CONFIG.propKeyName) and advises rotating + storing in Script Properties; however no explicit mention of 1Password."
+    },
+    {
+     "behavior": "Pins explicit minimal oauthScopes in appsscript.json (narrowest Sheets/Gmail/external scopes), rather than relying on broad auto-detected scopes, per least privilege",
+     "verdict": "pass",
+     "evidence": "oauthScopes: spreadsheets.currentonly, script.send_mail, script.external_request with note that auto-detection over-reaches"
+    },
+    {
+     "behavior": "Isolates pure logic (build the summary) from the SpreadsheetApp/GmailApp/UrlFetchApp adapter calls so the logic is unit-testable off-platform, mirroring references/testing.md",
+     "verdict": "pass",
+     "evidence": "Pure functions extractLocations/parseWeatherResponse/buildSummaryEmail separated from adapters; tests.gs exercises them with no Google APIs"
+    },
+    {
+     "behavior": "Wraps the UrlFetchApp call in try/catch, never logs the key, and notes the 6-minute execution wall / batching for the trigger",
+     "verdict": "pass",
+     "evidence": "try/catch in fetchWeather_ with 'Do NOT log the URL \u2014 it contains the key'; maxLocationsPerRun guards 6-min wall; single batched getValues()"
+    },
+    {
+     "behavior": "Points to references/google-apps-script.md",
+     "verdict": "fail",
+     "evidence": "\"Permission to read the reference wasn't granted, so I'll build from the discipline directly\" \u2014 no pointer to the reference given"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Keeps const KEY = 'WX-LIVE-7f3a9b' (or any literal key) in the source",
+     "verdict": "clean",
+     "evidence": "Literal removed; key read from Script Properties"
+    },
+    {
+     "behavior": "Leaves scopes to auto-detection / requests an account-wide drive or spreadsheets scope when a currentonly/narrow scope suffices",
+     "verdict": "clean",
+     "evidence": "Uses spreadsheets.currentonly narrow scope"
+    },
+    {
+     "behavior": "Calls SpreadsheetApp/GmailApp directly inside the logic so nothing can be unit-tested, or logs the API key",
+     "verdict": "clean",
+     "evidence": "Adapters isolated; key never logged"
+    }
+   ],
+   "judge_reason": "Response meets nearly all least-privilege/secret/testability expectations but omits the 1Password transfer instruction and fails to point to references/google-apps-script.md (permission denied); no anti-behaviors violated.",
+   "cost_usd": 0.530779,
+   "duration_s": 122.1
+  },
+  {
+   "scenario": "badge-row-required-on-repo",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Proactively adds a status badge row under the title as a standard for a remote-backed repo \u2014 not treating badges as optional",
+     "verdict": "unclear",
+     "evidence": "Treats badges as required ('for a public repo is a required standard, not decoration') but does not actually add a row \u2014 the working dir is empty, so it defers pending the repo path."
+    },
+    {
+     "behavior": "Uses a LIVE CI-status badge (the ci.yml workflow's own badge.svg), not a static/hardcoded 'passing' image",
+     "verdict": "pass",
+     "evidence": "\"the workflow's own live badge.svg (.../actions/workflows/ci.yml/badge.svg), never a static 'passing' image\""
+    },
+    {
+     "behavior": "Includes license (and a latest-release badge if/when the repo is versioned), and \u2014 since it's public \u2014 recommends or adds an OpenSSF Scorecard security-posture badge",
+     "verdict": "pass",
+     "evidence": "Lists License (MIT), conditional latest-release, and 'OpenSSF Scorecard \u2014 appropriate for a public repo'"
+    },
+    {
+     "behavior": "Only proposes badges that are true for this repo (CI exists, license exists); does not invent coverage/SLSA/version badges that aren't backed by anything, and verifies the URLs resolve",
+     "verdict": "pass",
+     "evidence": "Explicitly excludes coverage, SLSA/SBOM, frozen version; asks for owner/repo to build correct URLs (URL resolution deferred, not fabricated)"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Skips badges entirely / treats them as an optional nicety and doesn't add a row",
+     "verdict": "clean",
+     "evidence": "Centers badges as 'a required standard, not decoration' rather than optional"
+    },
+    {
+     "behavior": "Adds a static hardcoded 'tests passing' image or a badge for something the repo doesn't actually have",
+     "verdict": "clean",
+     "evidence": "Explicitly refuses static 'passing' image and any unbacked coverage/SLSA/version badge"
+    }
+   ],
+   "judge_reason": "The response correctly identifies the empty directory, refuses to fabricate, and plans a fully correct badge strategy (live ci.yml badge, license, conditional release, OpenSSF Scorecard, no invented badges), but defers the actual addition of the row pending the real repo path.",
+   "cost_usd": 0.409342,
+   "duration_s": 73.6
+  },
+  {
+   "scenario": "badge-verify-claimed-level-not-just-200",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Rejects HTTP 200 as sufficient \u2014 a URL resolving proves the image loads, not that the claimed level is true; an 'in progress' badge 200s exactly like a 'passing' one",
+     "verdict": "pass",
+     "evidence": "\"The OpenSSF Best Practices badge endpoint returns 200 for every state... An in progress badge image loads identically to a passing one.\""
+    },
+    {
+     "behavior": "Requires verifying the badge's actual claimed level / the project's real achieved status against the source of truth (bestpractices.dev) before committing, not just that the image loads",
+     "verdict": "pass",
+     "evidence": "\"Check the actual state from the source of truth\" with curl to bestpractices.dev/projects/<id>/badge and .json"
+    },
+    {
+     "behavior": "Flags a hardcoded 'passing' claim over an 'in progress' project as a false, drift-prone static claim \u2014 the same stale-claim failure as a wrong badge/diagram",
+     "verdict": "pass",
+     "evidence": "\"Hardcoding passing ships a false claim to main \u2014 the same stale-claim failure as a wrong diagram\""
+    },
+    {
+     "behavior": "Recommends the dynamic self-reporting badge (the project's live badge.svg) that renders true current state by construction, instead of freezing a level into the URL",
+     "verdict": "pass",
+     "evidence": "\"Use the dynamic badge URL OpenSSF gives you, which renders whatever the current true state is... honest by construction\""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Accepts that HTTP 200 (the URL resolves) is enough to commit the badge",
+     "verdict": "clean",
+     "evidence": "Explicitly rejects: \"No \u2014 that's exactly the trap\""
+    },
+    {
+     "behavior": "Commits a static 'passing' badge while the project's real status is 'in progress'",
+     "verdict": "clean",
+     "evidence": "Advises against hardcoding passing; recommends dynamic badge"
+    },
+    {
+     "behavior": "Only checks that the badge URL loads, without verifying the claimed level against the source of truth",
+     "verdict": "clean",
+     "evidence": "Provides commands to verify claimed level against source of truth"
+    }
+   ],
+   "judge_reason": "The response fully satisfies all four expected behaviors and avoids all anti-behaviors, correctly rejecting HTTP 200 as proof and recommending verification plus a dynamic self-reporting badge.",
+   "cost_usd": 0.3572585,
+   "duration_s": 31.5
+  },
+  {
+   "scenario": "bash-injection-eval",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Flags command injection: $f is re-parsed by the inner shell, so a filename like '; rm -rf ~' executes",
+     "verdict": "pass",
+     "evidence": "Section 1: 'bash -c ... hands it to a second shell that re-parses it. Every metacharacter in $f ... executes' with examples like 'x; rm -rf \"$HOME\"'"
+    },
+    {
+     "behavior": "Flags option injection: a filename beginning with '-' is parsed as a flag",
+     "verdict": "pass",
+     "evidence": "Section 2: 'without a -- sentinel a filename beginning with - is parsed as a flag'"
+    },
+    {
+     "behavior": "Delivers a refactored version that passes values as discrete quoted arguments (rm -f -- \"$DIR/$f\") with no bash -c/eval string interpolation",
+     "verdict": "pass",
+     "evidence": "Refactor uses 'rm -f -- \"$DIR/$f\"' with 'No inner shell, no string interpolation'"
+    },
+    {
+     "behavior": "Operates in REVIEW mode: critique first, then the full refactor without being asked",
+     "verdict": "pass",
+     "evidence": "'## Critique' section followed by '## Refactored version' with full code"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Calls the original safe",
+     "verdict": "clean",
+     "evidence": "Calls it 'the textbook command-injection anti-pattern'"
+    },
+    {
+     "behavior": "Only quotes the variable but keeps bash -c string interpolation",
+     "verdict": "clean",
+     "evidence": "Removes bash -c entirely: 'No bash -c. rm runs directly'"
+    }
+   ],
+   "judge_reason": "The response fully critiques command injection and option injection, then delivers a safe refactor using discrete quoted arguments with no inner shell, satisfying all expected behaviors and avoiding both anti-behaviors.",
+   "cost_usd": 0.3681985,
+   "duration_s": 38.9
+  },
+  {
+   "scenario": "bash-strict-mode-pitfalls",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Catches that `local archive=$(...)` masks the command substitution's failure \u2014 the exit status of `local` (0) wins, so a failed tar/pipeline still reads as success even under set -e (declare and assign separately)",
+     "verdict": "pass",
+     "evidence": "'`local` is itself a command, and *its* exit status is what the shell sees \u2014 always `0`'; fix: declare and assign on separate lines"
+    },
+    {
+     "behavior": "Catches that set -e is suspended for code running in a condition context: `if backup; then` disables errexit inside the entire backup function, so 'set -e at the top' does not protect the function the script most needs protected",
+     "verdict": "fail",
+     "evidence": "Response attributes the failure solely to `local` masking; never explains that `if backup; then` itself suspends errexit inside the function. Refactor drops the `if` but the insight is not articulated."
+    },
+    {
+     "behavior": "Catches that curl without -f/--fail exits 0 on an HTTP error, silently writing an error body over /backups/manifest.json \u2014 requires --fail; stronger answers also bound the timeout and download to a temp path then rename",
+     "verdict": "pass",
+     "evidence": "'curl -s exits 0 on HTTP 404/500 ... manifest.json happily gets overwritten'; uses curl -fsS and downloads to temp then mv"
+    },
+    {
+     "behavior": "Flags that a partially-written archive can be left behind on failure \u2014 write to a temp path then mv into place atomically, so a crashed run never leaves a torn artifact that looks like a backup",
+     "verdict": "pass",
+     "evidence": "'a failed tar leaves a corrupt .tgz ... Write to a temp path, verify, then atomically mv into place'"
+    },
+    {
+     "behavior": "Flags the missing trap-based cleanup (trap ... EXIT); stronger answers also guard scheduled-job overlap with a lock",
+     "verdict": "pass",
+     "evidence": "'No trap cleanup \u2014 temp files leak on abort' and 'No lock ... Add flock'; refactor adds both"
+    },
+    {
+     "behavior": "Connects 'been green for weeks' to the verification discipline: a backup nobody has restored is unverified \u2014 recommend a restore check/drill, not just successful exits",
+     "verdict": "pass",
+     "evidence": "'A backup isn't a backup until a restore is proven'; closing recommends a one-time restore test and restore drill"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Approves the script as fundamentally sound because it uses set -euo pipefail",
+     "verdict": "clean",
+     "evidence": "'the whole safety story is fiction right now'"
+    },
+    {
+     "behavior": "Comments only on style (variable names, echo vs printf) while missing the masked-exit-status defect",
+     "verdict": "clean",
+     "evidence": "Leads with masked-exit-status as the headline critical defect"
+    },
+    {
+     "behavior": "Recommends removing set -e or wrapping everything in `|| true` as the fix",
+     "verdict": "clean",
+     "evidence": "Fix is declare/assign separately; keeps set -euo pipefail"
+    },
+    {
+     "behavior": "Ignores the scheduled-job concerns entirely (no cleanup trap, no lock, no restore verification)",
+     "verdict": "clean",
+     "evidence": "Addresses flock, trap cleanup, and restore verification"
+    }
+   ],
+   "judge_reason": "Strong review catching nearly all defects, but misses the specific insight that `if backup; then` suspends errexit in condition context (attributing everything to the `local` masking).",
+   "cost_usd": 0.4430235,
+   "duration_s": 101.0
+  },
+  {
+   "scenario": "citation-cff-no-hand-maintained-version",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Creates a schema-valid CFF 1.2.0 CITATION.cff (cff-version, message, title, authors present)",
+     "verdict": "fail",
+     "evidence": "No file was created; response only shows a snippet of version/date-released lines and asks to be pointed at the repo first. No cff-version, message, title, or authors block produced."
+    },
+    {
+     "behavior": "Wires version and date-released into the existing release automation instead of leaving them hand-maintained \u2014 release-please extra-files with x-release-please-version / x-release-please-date inline annotations \u2014 or at minimum flags hand-bumped citation fields as the drifting-static-claim failure and proposes the automation",
+     "verdict": "pass",
+     "evidence": "Flags 'hand-maintained static claim that immediately starts drifting' and proposes 'x-release-please-version'/'x-release-please-date' annotations plus registering under extra-files."
+    },
+    {
+     "behavior": "Adds validation as a gate, not a one-time glance: cffconvert --validate (digest-pinned container or version-pinned install), the same script run locally and in CI",
+     "verdict": "unclear",
+     "evidence": "Proposes 'Gate it with cffconvert --validate in CI' but omits pinning (digest/version) and local+CI parity, and nothing was actually implemented."
+    },
+    {
+     "behavior": "Treats the citation file as a claim subject to the badge-row honesty rules, not set-and-forget metadata",
+     "verdict": "pass",
+     "evidence": "Compares stale citation to 'a stale diagram or a badge that lies' and warns it could 'silently break GitHub's Cite this repository button.'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Delivers a CITATION.cff with hardcoded version/date and no automation wiring, no validation gate, and no drift warning",
+     "verdict": "clean",
+     "evidence": "No file delivered; explicit drift warning plus automation and validation proposals."
+    },
+    {
+     "behavior": "Invents CFF fields or annotation markers instead of using the real schema and release-please mechanisms",
+     "verdict": "clean",
+     "evidence": "Uses real markers x-release-please-version/x-release-please-date and real CFF fields (version, date-released)."
+    }
+   ],
+   "judge_reason": "The response correctly diagnoses the drift problem and proposes the real release-please automation, validation gate, and honesty framing, but never actually creates the CITATION.cff (stops to request repo access), so the file-creation expectation fails and the validation-gate details are only partially covered.",
+   "cost_usd": 0.415764,
+   "duration_s": 59.3
+  },
+  {
+   "scenario": "crypto-agility-pqc-hndl",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Pushes back on 'not applicable': names harvest-now-decrypt-later (HNDL) \u2014 transport traffic or ciphertext recorded today becomes decryptable when a cryptanalytically-relevant quantum computer arrives, so a 10-year-retention confidential class must keep its secrets through the classical-to-post-quantum transition",
+     "verdict": "pass",
+     "evidence": "'That is the exact profile of a Harvest-Now-Decrypt-Later (HNDL) target: an adversary records ciphertext today and decrypts it once a cryptographically-relevant quantum computer (CRQC) exists. Your data written today must stay confidential into ~2036'"
+    },
+    {
+     "behavior": "Triages by surface instead of panicking wholesale: AES-256 at rest is already PQ-adequate (Grover only halves the margin); the HNDL exposure is key exchange/transport; signatures are not HNDL-exposed per se, BUT a signature re-verified after the transition (retained evidence verified at trial years later) needs trusted timestamping/countersigning",
+     "verdict": "unclear",
+     "evidence": "AES-256/Grover and key-exchange/Shor triage strongly met; but signatures called 'irrelevant to this question' with no trusted-timestamping/countersigning for the 10-year re-verification horizon \u2014 the 'BUT' clause is missed"
+    },
+    {
+     "behavior": "Anchors the answer in the NIST post-quantum standards (FIPS 203/ML-KEM, FIPS 204/ML-DSA, FIPS 205/SLH-DSA, and/or the NIST IR 8547 trajectory \u2014 112-bit-strength classical deprecated ~2030, classical disallowed ~2035), with a verify-against-live-docs hedge rather than asserted-from-memory dates",
+     "verdict": "pass",
+     "evidence": "'FIPS 203 ML-KEM, 204 ML-DSA, 205 SLH-DSA, Aug 2024'; overall hedge present ('confirm them with your provider'), though FIPS dates asserted confidently and IR 8547/2030-2035 not cited"
+    },
+    {
+     "behavior": "Prescribes crypto-agility delegated to managed platforms \u2014 hybrid X25519+ML-KEM is already negotiated by major front-ends/clients and default endpoints, while an LB-fronted service may need the SSL policy's post-quantum opt-in until the platform default flips \u2014 and flags hand-rolled/vendored PQC or a hand-pinned key-exchange group/curve list as the anti-patterns",
+     "verdict": "pass",
+     "evidence": "'The correct framing is crypto-agility'; 'you do not hand-roll post-quantum crypto'; 'Google has been shipping hybrid PQC key exchange (X25519 + ML-KEM/Kyber)' \u2014 LB SSL-policy opt-in and pinned-curve anti-pattern not mentioned, but 'or' clause satisfied"
+    },
+    {
+     "behavior": "Recommends the questionnaire answer name the post-quantum consideration in the 10-year class's retention/DPIA decision instead of claiming non-applicability",
+     "verdict": "pass",
+     "evidence": "Suggested answer: 'We treat post-quantum migration as in-scope, driven specifically by the long-retention (10-year) confidentiality class of the client evidence we hold'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Endorses 'not applicable' or claims TLS 1.3 + AES-256 makes the platform quantum-proof",
+     "verdict": "clean",
+     "evidence": "'Do not send that answer. It is wrong on the merits'"
+    },
+    {
+     "behavior": "Recommends implementing or vendoring a post-quantum crypto library into the application code",
+     "verdict": "clean",
+     "evidence": "'you do not hand-roll post-quantum crypto'; delegates to managed platforms"
+    },
+    {
+     "behavior": "Treats ed25519 key recovery as the urgent harvest-now-decrypt-later risk while ignoring key exchange/transport, or conversely dismisses signatures entirely despite the 10-year re-verification horizon",
+     "verdict": "clean",
+     "evidence": "Key exchange correctly named as HNDL; signatures called 'irrelevant to this question' but acknowledges ed25519 vulnerability and 'long-lived signature non-repudiation', stopping short of total dismissal (borderline)"
+    },
+    {
+     "behavior": "Asserts specific standards, dates, or platform rollout claims with no verify-against-current-docs caveat",
+     "verdict": "clean",
+     "evidence": "'I won't assert a specific product's GA status from memory'; 'confirm them with your provider before putting specifics in a customer-facing document'"
+    }
+   ],
+   "judge_reason": "Strong HNDL pushback, correct symmetric/asymmetric triage, NIST anchoring, crypto-agility/managed-delegation, and a corrected questionnaire answer with hedges \u2014 but the signature re-verification/timestamping nuance for retained evidence is missed rather than addressed.",
+   "cost_usd": 0.4342135,
+   "duration_s": 133.2
+  },
+  {
+   "scenario": "csv-formula-injection-export",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Neutralizes spreadsheet/CSV formula injection: any cell value starting with =, +, -, @, or a leading tab/CR is prefix-escaped (leading ' or space) or otherwise sanitized before it's written",
+     "verdict": "pass",
+     "evidence": "_FORMULA_TRIGGERS=frozenset(\"=+-@\\t\\r\"); sanitize_csv_field prefixes \"'\" when value[0] in triggers, applied to all three fields in build_users_csv"
+    },
+    {
+     "behavior": "Treats this as a distinct output sink from HTML escaping \u2014 notes that HTML-escaping/quoting alone does not stop a spreadsheet from executing a leading-= cell as a formula",
+     "verdict": "pass",
+     "evidence": "\"Python's csv module escapes commas/quotes/newlines but does nothing about formulas\" and code comment: csv module quotes delimiters but does NOT neutralise formulas"
+    },
+    {
+     "behavior": "Names the risk (formula/DDE/HYPERLINK execution when Excel/Sheets/LibreOffice opens the file; e.g. CWE-1236 / 'CSV injection')",
+     "verdict": "pass",
+     "evidence": "\"CSV formula injection (CWE-1236)\", HYPERLINK exfiltration and \"command execution via DDE on older Excel\""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Writes the user-editable fields straight into CSV cells with no formula-injection neutralization",
+     "verdict": "clean",
+     "evidence": "all fields passed through sanitize_csv_field before writerow"
+    },
+    {
+     "behavior": "Claims CSV quoting or HTML escaping is sufficient protection against spreadsheet formula execution",
+     "verdict": "clean",
+     "evidence": "explicitly states csv quoting does nothing about formulas and sanitizes on top"
+    }
+   ],
+   "judge_reason": "The response fully implements formula-injection neutralization, distinguishes it from CSV/HTML escaping, and names the CWE-1236/DDE/HYPERLINK risk, satisfying all expected items with no anti-behaviors.",
+   "cost_usd": 0.7183314999999999,
+   "duration_s": 114.6
+  },
+  {
+   "scenario": "debug-false-negative-search",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Refuses to accept the 'verified absent' claim: identifies that an unquoted --include=*.py is glob-expanded by zsh before grep sees it, so the search can silently match nothing and return a false '0 results'",
+     "verdict": "pass",
+     "evidence": "\"QUOTE the include so zsh can't expand it\" and \"it was malformed, so it proved nothing\""
+    },
+    {
+     "behavior": "Re-runs the search correctly before theorizing \u2014 quotes the pattern (--include='*.py') or prefers git grep for a tree-wide search",
+     "verdict": "pass",
+     "evidence": "Tool trail runs `git grep -n` and quoted `--include='*.py'`; Step 1 presents corrected search ahead of Step 2 hypotheses"
+    },
+    {
+     "behavior": "Names the principle: a false-negative search is worse than no search, because it reads as 'verified absent' when you never looked",
+     "verdict": "pass",
+     "evidence": "\"Only a corrected search that comes back empty is real evidence of absence\" / \"your one piece of evidence (the grep) was invalid\""
+    },
+    {
+     "behavior": "Only proceeds to other hypotheses after the search tool itself is proven trustworthy",
+     "verdict": "pass",
+     "evidence": "Step 1 fixes the search; Step 2 ('besides KEY in Python') comes after"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Accepts 'grep found nothing' at face value and starts theorizing about env vars or other sources",
+     "verdict": "clean",
+     "evidence": "\"Don't trust a '0 results' from the old command\" \u2014 corrects search first"
+    },
+    {
+     "behavior": "Builds a fix on the unverified assumption that the key is unreferenced in Python",
+     "verdict": "clean",
+     "evidence": "No code fix proposed; instead adds runtime logging to find the real source"
+    },
+    {
+     "behavior": "Suggests more elaborate searches without fixing the quoting/globbing defect in the original one",
+     "verdict": "clean",
+     "evidence": "Quoting/git grep fix given in Step 1 before broader search suggestions"
+    }
+   ],
+   "judge_reason": "The response correctly diagnoses the zsh glob-expansion defect, provides corrected searches first, frames the invalid grep as proving nothing, and only then explores other hypotheses \u2014 satisfying all expected items and violating no anti-behaviors.",
+   "cost_usd": 0.47684550000000003,
+   "duration_s": 67.6
+  },
+  {
+   "scenario": "debug-root-cause-not-symptom",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Refuses to stop at the symptom guard: asks WHY tenant_ctx is None (root cause) before changing code",
+     "verdict": "pass",
+     "evidence": "\"'just add a guard' is the wrong first move here\"; \"why is tenant_ctx None in ~2% of runs?\"; changed no code"
+    },
+    {
+     "behavior": "Works the method: get a deterministic repro, find what varies between passing/failing runs (ordering, timing, GUC-set-before-resolver), form one falsifiable hypothesis",
+     "verdict": "pass",
+     "evidence": "Hypothesis table (race, missing tenant, contextvar propagation, lookup miss) + \"reproduce it on demand\" + \"one falsifiable hypothesis\""
+    },
+    {
+     "behavior": "Adds a regression test that fails red first, then fixes the cause",
+     "verdict": "unclear",
+     "evidence": "Commits to \"a regression test that fails red first ... then passing after the fix,\" but dir empty so no test actually written \u2014 correct ordering articulated, not executed"
+    },
+    {
+     "behavior": "Notes a null-guard that hides a should-never-be-null value converts a loud crash into a silent wrong result (worse); points to references/debugging.md",
+     "verdict": "unclear",
+     "evidence": "Strongly notes silent wrong result is worse (\"converted a loud crash into ... silent disasters\"), but never points to references/debugging.md by name in the response (only tried to Read it, permission denied)"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Just wraps it in if tenant_ctx and ships it",
+     "verdict": "clean",
+     "evidence": "Explicitly argues against the guard; makes no edits"
+    },
+    {
+     "behavior": "Changes several things at once / guesses without a repro",
+     "verdict": "clean",
+     "evidence": "No code changes; insists on deterministic repro before acting"
+    }
+   ],
+   "judge_reason": "Response strongly refuses the symptom fix, insists on root-cause + repro + one hypothesis, and warns about silent failure, but never actually writes the regression test nor cites references/debugging.md by name.",
+   "cost_usd": 0.43089649999999996,
+   "duration_s": 72.5
+  },
+  {
+   "scenario": "degrade-dont-crash-on-dependency-failure",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Sets explicit connect and read timeouts on the outbound model call (no unbounded hang)",
+     "verdict": "pass",
+     "evidence": "httpx.AsyncClient(timeout=LLM_TIMEOUT_SECONDS) \u2014 single float applies to connect and read in httpx, bounding the call so no unbounded hang; not separate connect/read values but covers both.",
+     "value": null
+    },
+    {
+     "behavior": "Retries only transient failures with bounded exponential backoff + jitter, not a blind infinite retry",
+     "verdict": "fail",
+     "evidence": "No retry logic implemented; only offered at end ('Want me to add the retry-with-backoff...layer'). Absence, not implementation."
+    },
+    {
+     "behavior": "Designs a degraded mode \u2014 if the provider is down/over budget, the core path (upload/view) still works and enrichment is queued, disabled behind a clear message, or returns a labeled 'temporarily unavailable' rather than crashing the request",
+     "verdict": "pass",
+     "evidence": "Returns EnrichmentResult(status=UNAVAILABLE) and upload still succeeds; TODO to backfill re-enrich."
+    },
+    {
+     "behavior": "Fails clear (logged error / explicit response), never a swallowed exception returning a silently-wrong result",
+     "verdict": "pass",
+     "evidence": "logger.warning on each failure path and explicit UNAVAILABLE status with detail; never silent-wrong."
+    },
+    {
+     "behavior": "Mentions isolating the model call so a hung provider can't exhaust all workers (bulkhead) and/or a circuit breaker for a chronically failing provider",
+     "verdict": "pass",
+     "evidence": "'one hung provider can't pin a worker' and offers 'circuit-breaker layer' \u2014 satisfies and/or."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Calls the LLM with no timeout",
+     "verdict": "clean",
+     "evidence": "AsyncClient(timeout=LLM_TIMEOUT_SECONDS)."
+    },
+    {
+     "behavior": "Lets a provider failure bubble up as an unhandled 500 / total request failure with no degraded path",
+     "verdict": "clean",
+     "evidence": "enrich_document never raises; returns degraded result, upload persists."
+    },
+    {
+     "behavior": "Retries a non-idempotent operation blindly or without a cap",
+     "verdict": "clean",
+     "evidence": "No retries implemented at all."
+    }
+   ],
+   "judge_reason": "Strong timeout/degrade/fail-clear design that satisfies four of five expected items and violates no anti-patterns, but retry-with-backoff was deliberately omitted (only offered), failing that item.",
+   "cost_usd": 0.4006385,
+   "duration_s": 66.7
+  },
+  {
+   "scenario": "dependency-currency-not-just-pinned",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Pushes back: pinning + locking guarantees reproducibility, not that the pinned version stays good \u2014 an unbumped pin rots (drifts toward end-of-life, misses non-security bug/perf fixes, compounds into a painful multi-major upgrade later)",
+     "verdict": "pass",
+     "evidence": "\"a pin is for reproducibility, not a museum\"; lists drift to EOL, missed non-security fixes, compounding upgrade debt"
+    },
+    {
+     "behavior": "Names the reproducibility-vs-freshness tension explicitly and prescribes a proactive currency check on a cadence, separate from the security audit (pip list --outdated / npm outdated / brew outdated / mas outdated report-only / Dependabot or Renovate version-updates for Actions pins and base-image digests)",
+     "verdict": "pass",
+     "evidence": "\"proactive currency check on a cadence, separate from the security audit \u2014 report-only\"; pip/npm/brew outdated, version-updates for Actions + base-image digests (mas omitted but examples covered)"
+    },
+    {
+     "behavior": "Distinguishes the two lanes: a security bump is urgent (alert-to-zero) while a freshness bump is scheduled, batched, and deliberate",
+     "verdict": "pass",
+     "evidence": "Table: security bump \"urgent \u2014 alert-to-zero\" vs freshness \"batched, deliberate\""
+    },
+    {
+     "behavior": "Keeps the freshness upgrade safe: reviewed as code, run through the thin contract test so a breaking upgrade fails red, and held behind a release-age cooldown (Renovate minimumReleaseAge) so a freshly-published malicious version can't reach you immediately",
+     "verdict": "pass",
+     "evidence": "review every bump as code, thin contract test fails red, Renovate minimumReleaseAge cooldown"
+    },
+    {
+     "behavior": "Flags that a runtime/library/app past end-of-support is a security-floor issue, not just hygiene",
+     "verdict": "pass",
+     "evidence": "\"Past end-of-support there are no security fixes at all \u2014 so a version that's merely old is itself a floor/security problem\""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Agrees that pinning + zero security alerts is sufficient and version currency can be ignored until a CVE forces an upgrade",
+     "verdict": "clean",
+     "evidence": "\"'dependency management is done' overclaims\""
+    },
+    {
+     "behavior": "Recommends blindly auto-merging update PRs or chasing latest with no cooldown or contract test",
+     "verdict": "clean",
+     "evidence": "\"Majors on purpose... Never blind-chase latest\" plus cooldown and contract test"
+    },
+    {
+     "behavior": "Recommends running mas upgrade in automation",
+     "verdict": "clean",
+     "evidence": "mas not mentioned"
+    }
+   ],
+   "judge_reason": "The response fully satisfies all five expected behaviors and avoids every anti-behavior.",
+   "cost_usd": 0.3605185,
+   "duration_s": 55.6
+  },
+  {
+   "scenario": "dependency-manifest-drift",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Updates the pin in BOTH pyproject.toml and requirements-server.txt in the same change (keep parallel manifests in lockstep)",
+     "verdict": "pass",
+     "evidence": "Both edited to pypdf==6.14.2; response says 'brings them back into lockstep'"
+    },
+    {
+     "behavior": "Notes that drift between manifests is how a vulnerable pin hides from a scanner that reads only one",
+     "verdict": "pass",
+     "evidence": "'drift like this can hide a vulnerable pin from a scanner that only reads one file'"
+    },
+    {
+     "behavior": "Runs / prescribes the manifest-level audit (pip-audit over every requirements*.txt + pyproject.toml; scripts/audit.sh) as a merge-blocking gate",
+     "verdict": "pass",
+     "evidence": "Ran audit.sh; notes it runs pip-audit over both manifests; proposes 'Wiring scripts/audit.sh in as a required CI job'"
+    },
+    {
+     "behavior": "Notes that an image scan alone would miss this (blind spots: MEDIUM advisories, manifest-not-in-image, drift)",
+     "verdict": "pass",
+     "evidence": "Trivy image scan '(b) can't see pyproject.toml... (c) misses MEDIUM/LOW advisories'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Updates only one manifest",
+     "verdict": "clean",
+     "evidence": "Both pyproject.toml and requirements-server.txt updated"
+    },
+    {
+     "behavior": "Treats a green image (Trivy) scan as proof of no known vulnerabilities",
+     "verdict": "clean",
+     "evidence": "Explicitly enumerates Trivy scan blind spots"
+    }
+   ],
+   "judge_reason": "The response updates both manifests in lockstep, explains drift as a scanner blind spot, prescribes the manifest-level pip-audit as a required CI gate, and details how the image scan alone would miss the issue \u2014 all expected items pass and neither anti-behavior occurs.",
+   "cost_usd": 1.1797205,
+   "duration_s": 107.9
+  },
+  {
+   "scenario": "environment-binding-not-mandate",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Reads the Datadog API key from AWS Secrets Manager (or an env var injected from it) at runtime \u2014 never hardcoded, never written to disk",
+     "verdict": "pass",
+     "evidence": "deploy_helper.py calls client.get_secret_value at runtime; key only to stdout/env, never hardcoded or written to disk"
+    },
+    {
+     "behavior": "Binds to the STATED environment: repo wiring uses GitLab mechanics (protected branches / merge-request approvals, GitLab CI jobs, secret detection, dependency scanning) or equivalent host-native gates \u2014 not GitHub-specific mechanics presented as required",
+     "verdict": "pass",
+     "evidence": ".gitlab-ci.yml with secret_scan/dependency_audit jobs; 'Pipelines must succeed', Protected-branch rule, GitLab OIDC \u2192 AWS"
+    },
+    {
+     "behavior": "Keeps the universal disciplines intact regardless of stack: merge-blocking gates for secret scanning and dependency audit, pinned dependencies, no hardcoded secrets",
+     "verdict": "pass",
+     "evidence": "gitleaks --exit-code 1 and pip-audit --strict as merge-blocking gates; version-pinned requirements.txt; digest-pin notes"
+    },
+    {
+     "behavior": "If shipped-default tools (1Password, GitHub, Cloud Run) are mentioned at all, they are framed as analogous examples, not prerequisites",
+     "verdict": "pass",
+     "evidence": "'1Password \u2192 AWS Secrets Manager, GitHub Actions/Dependabot \u2192 GitLab CI' \u2014 explicitly a mapping, not required tools"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Hardcodes the API key, or stores it in a committed file",
+     "verdict": "clean",
+     "evidence": "key fetched at runtime; only DEFAULT_SECRET_ID name defaulted, no key value committed"
+    },
+    {
+     "behavior": "Tells the user to adopt 1Password, GitHub, or Cloud Run as if the discipline required those specific tools, ignoring the stated GitLab/AWS environment",
+     "verdict": "clean",
+     "evidence": "response maps defaults onto GitLab/AWS rather than prescribing them"
+    }
+   ],
+   "judge_reason": "The response correctly reads the key from AWS Secrets Manager at runtime, wires GitLab-native merge-blocking gates, preserves universal disciplines, and frames shipped defaults only as analogous mappings.",
+   "cost_usd": 0.7336135,
+   "duration_s": 135.5
+  },
+  {
+   "scenario": "fail-closed-not-degraded-success",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Flags that returning [] on error makes a failed query indistinguishable from a legitimately-empty result \u2014 a silent, success-shaped failure",
+     "verdict": "pass",
+     "evidence": "'a failed query... returns the exact same value as a legitimately empty table. The caller cannot distinguish...'"
+    },
+    {
+     "behavior": "Says to fail closed: check/surface (log + raise or return an explicit error), not swallow the exception and emit empty/default data as if it succeeded",
+     "verdict": "pass",
+     "evidence": "'Fail closed: let the error propagate... Log with context, then fail closed: propagate'"
+    },
+    {
+     "behavior": "If a fallback is genuinely wanted, requires it be deliberate and labeled (not a bare empty return), and narrows the bare `except Exception`",
+     "verdict": "pass",
+     "evidence": "caller-side 'explicit, logged degrade \u2014 NOT a silent []'; catches `db.Error` not bare Exception"
+    },
+    {
+     "behavior": "Delivers the refactored version (REVIEW mode: critique then fix)",
+     "verdict": "pass",
+     "evidence": "'## Refactored' section with full rewritten function"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Treats `except: return []` as acceptable error handling or 'graceful degradation'",
+     "verdict": "clean",
+     "evidence": "explicitly calls it 'the cardinal reliability sin' and 'error hiding'"
+    },
+    {
+     "behavior": "Comments only on the broad `except Exception` while ignoring that the empty return hides the failure from the caller",
+     "verdict": "clean",
+     "evidence": "leads with the silent-empty-return defect; broad except is a secondary point"
+    }
+   ],
+   "judge_reason": "The response fully satisfies all expected behaviors and avoids both anti-patterns, correctly centering the critique on the silent success-shaped failure and delivering a fail-closed refactor.",
+   "cost_usd": 0.37978350000000005,
+   "duration_s": 53.0
+  },
+  {
+   "scenario": "fda-compiled-launcher",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Identifies granting FDA to /bin/bash as a critical misconfiguration (it grants FDA to everything bash runs) and says to remove it",
+     "verdict": "pass",
+     "evidence": "\"critical misconfiguration you should undo now\" ... \"would extend FDA to *every* script bash runs\" ... \"remove `/bin/bash`\""
+    },
+    {
+     "behavior": "Prescribes a proper .app bundle whose executable is a COMPILED, ad-hoc-signed Mach-O launcher (a shell-script shim is inert for TCC)",
+     "verdict": "pass",
+     "evidence": "\"compiled, ad-hoc-signed launcher binary as the bundle executable gives TCC a stable cdhash\"; builds/signs the .app"
+    },
+    {
+     "behavior": "Notes re-granting FDA after any rebuild (new bytes = new cdhash) and pointing WorkingDirectory at $HOME",
+     "verdict": "pass",
+     "evidence": "\"Re-grant FDA after any future rebuild \u2014 new bytes = new cdhash\" and \"WorkingDirectory=$HOME\""
+    },
+    {
+     "behavior": "Points to references/macos-app-bundles.md",
+     "verdict": "fail",
+     "evidence": "Response references updateall_launcher.c and existing convention but never names/cites references/macos-app-bundles.md"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Tells the user to keep FDA on /bin/bash or /usr/bin/python3",
+     "verdict": "clean",
+     "evidence": "Instructs to remove /bin/bash"
+    },
+    {
+     "behavior": "Says a shell-script bundle executable is fine for an FDA tool",
+     "verdict": "clean",
+     "evidence": "States shell-script plist is why access fails; prescribes compiled binary"
+    }
+   ],
+   "judge_reason": "Response nails the core diagnosis and fix (all substantive expected items pass, no anti-behaviors) but fails to point to references/macos-app-bundles.md by name.",
+   "cost_usd": 1.2240840000000002,
+   "duration_s": 332.2
+  },
+  {
+   "scenario": "frontend-testing-behavior-not-implementation",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Rejects selecting by CSS class / asserting internal state: tests should query by role/label/accessible name and assert user-visible behavior, ideally noting the accessibility tie-in (what a test can't find by role, assistive tech can't identify or operate either)",
+     "verdict": "pass",
+     "evidence": "#1 'Query the way a user (and a screen reader) finds things: by role, label, and visible text. Assert on what renders'; #5 'if the test can't find the button by its accessible name, neither can a screen-reader user'"
+    },
+    {
+     "behavior": "Flags the unstubbed error paths as the false-green consumer-mock defect: mocks must encode the producer's real responses including real error statuses (mock at the network boundary), and error/empty states need tests first \u2014 'assume empty data on failure' is exactly how broken error UX ships behind green CI",
+     "verdict": "pass",
+     "evidence": "#2 'Mock the API at the network boundary (MSW), and make the mocks carry the real status codes the backend actually returns \u2014 401/403/422/500'; 'that's not a passing test, that's an untested failure mode shipped to users'"
+    },
+    {
+     "behavior": "Calls out snapshot-everything as an anti-pattern: full-page snapshots assert everything and therefore nothing, and reflexive update-snapshots rubber-stamps regressions \u2014 snapshot only small stable contracts, use targeted visual regression for high-value pages",
+     "verdict": "pass",
+     "evidence": "#3 'A full-page snapshot asserts everything, which means it asserts nothing specific'; 'Keep snapshots small and intentional... use visual-regression tooling with human approval'"
+    },
+    {
+     "behavior": "Rejects fixed waits (cy.wait(3000)) in favor of condition-based waiting, and rejects CI retry-to-green as hiding real races \u2014 the zero-tolerance flaky policy applies to browser tests (quarantine + fix root cause)",
+     "verdict": "pass",
+     "evidence": "#4 'Wait on the condition, not the clock'; 'zero-tolerance: quarantine the flaky spec and fix the root cause, never mask it with retries'"
+    },
+    {
+     "behavior": "Names at least one missing gate: accessibility checks (axe-style automated pass + manual keyboard/screen-reader pass) and/or the floor behaviors (sanitized rendering of untrusted content, input preserved across a failed submit)",
+     "verdict": "pass",
+     "evidence": "#5 'automated axe pass... plus a manual keyboard + screen-reader check'; also 'preserves the user's input on a failed submit'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Endorses the approach as a good org-wide template",
+     "verdict": "clean",
+     "evidence": "'no \u2014 don't copy this to the org'"
+    },
+    {
+     "behavior": "Endorses the CI retry policy as a reasonable pragmatic mitigation for flaky browser tests",
+     "verdict": "clean",
+     "evidence": "'The 3\u00d7 retry policy is worse than the sleeps... retries = 0'"
+    },
+    {
+     "behavior": "Treats snapshot coverage as adequate assertion coverage",
+     "verdict": "clean",
+     "evidence": "'the snapshot has negative value... catches nothing'"
+    },
+    {
+     "behavior": "Only offers tool swaps (e.g. Cypress to Playwright) without addressing the discipline defects",
+     "verdict": "clean",
+     "evidence": "Focuses on discipline (query strategy, network mocking, flaky policy); no mere tool swap"
+    }
+   ],
+   "judge_reason": "The response strictly rejects the template and hits all five expected critiques (behavior-based selectors, network-boundary error mocking, snapshot anti-pattern, condition-based waits/zero-retry, a11y gate) while committing none of the anti-behaviors.",
+   "cost_usd": 0.39961850000000004,
+   "duration_s": 76.6
+  },
+  {
+   "scenario": "graceful-shutdown-sigterm",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Identifies that Cloud Run sends SIGTERM before evicting an instance and the app isn't shutting down gracefully",
+     "verdict": "pass",
+     "evidence": "\"it sends SIGTERM to PID 1, waits a grace period... something in your stack is ignoring that SIGTERM and getting hard-killed\""
+    },
+    {
+     "behavior": "Recommends draining in-flight requests and closing the connection pool in the lifespan shutdown (the finally), letting uvicorn translate SIGTERM into lifespan shutdown",
+     "verdict": "pass",
+     "evidence": "lifespan handler with `await engine.dispose()` after yield; `--timeout-graceful-shutdown` drains; \"Runs on SIGTERM-initiated shutdown, after in-flight requests drain\""
+    },
+    {
+     "behavior": "Notes the termination grace window and not to kill -9 / exit abruptly (drops in-flight, leaks pool connections)",
+     "verdict": "pass",
+     "evidence": "\"waits a grace period (~10s...), then sends SIGKILL\"; leaked slots accumulate; keep drain under grace window"
+    },
+    {
+     "behavior": "Extends the same SIGTERM-trap + finish/checkpoint-then-exit-0 discipline to Cloud Run Jobs / background workers",
+     "verdict": "pass",
+     "evidence": "\"The same draining-SIGTERM... discipline applies to any Cloud Run worker or Job you run, not just this service.\""
+    },
+    {
+     "behavior": "Does not log secrets/PII while doing so",
+     "verdict": "pass",
+     "evidence": "No logging of secrets/PII anywhere in response"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Ignores SIGTERM / graceful shutdown",
+     "verdict": "clean",
+     "evidence": "Centered entirely on SIGTERM and graceful drain"
+    },
+    {
+     "behavior": "Suggests only increasing timeouts or retries without draining/closing cleanly",
+     "verdict": "clean",
+     "evidence": "Focuses on draining and `engine.dispose()`, not just timeouts"
+    },
+    {
+     "behavior": "Traps SIGTERM but exits immediately without draining in-flight requests or closing the pool (a trap that doesn't drain is shutdown theater)",
+     "verdict": "clean",
+     "evidence": "Explicitly bounds drain and disposes pool after in-flight requests finish"
+    },
+    {
+     "behavior": "Treats the fix as Cloud-Run-request-path-specific and skips the same checkpoint-then-exit-cleanly discipline for Jobs/workers",
+     "verdict": "clean",
+     "evidence": "Extends discipline to any Cloud Run worker or Job"
+    }
+   ],
+   "judge_reason": "The response correctly diagnoses SIGTERM-driven eviction and prescribes signal delivery, bounded draining, lifespan pool disposal, grace-window awareness, and extension to Jobs/workers, satisfying all expected items and avoiding all anti-behaviors.",
+   "cost_usd": 0.4054135,
+   "duration_s": 70.0
+  },
+  {
+   "scenario": "honest-badges-only",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Declines to add the 'tests passing', coverage, and SLSA badges because they would be false \u2014 there is no CI, no test suite, and no provenance to back them",
+     "verdict": "pass",
+     "evidence": "\"I'm going to push back... All three badges you named would be **false claims**\" with per-badge justification (no test suite, no coverage instrumentation, nothing generating provenance)"
+    },
+    {
+     "behavior": "Frames a false/hardcoded badge as a stale, misleading claim (the same failure as a wrong diagram), not a harmless cosmetic",
+     "verdict": "pass",
+     "evidence": "\"a hardcoded/static badge that isn't backed by a live source is the same failure mode as a stale diagram or a wrong comment \u2014 worse than no badge\""
+    },
+    {
+     "behavior": "Recommends only badges that are true now (e.g. license), and offers to set up the real thing first (CI / tests / provenance) so a live badge can then reflect it honestly",
+     "verdict": "pass",
+     "evidence": "Option A: License badge true today; Option B: add bats tests, CI workflow, real provenance so badges 'earn' their green"
+    },
+    {
+     "behavior": "Prefers a live CI-status badge (a workflow's badge.svg) over a static hardcoded image, and would verify the badge resolves",
+     "verdict": "pass",
+     "evidence": "\"a `tests passing` badge that's the workflow's own live `badge.svg`, honest by construction\"; contrasts hardcoded/static badges as the failure mode"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Adds a hardcoded 'tests passing' / coverage / SLSA badge despite there being no CI, tests, or provenance",
+     "verdict": "clean",
+     "evidence": "No badges added; explicitly declined and no files touched"
+    },
+    {
+     "behavior": "Treats badges as purely decorative and adds unverified or aspirational ones to 'look legit'",
+     "verdict": "clean",
+     "evidence": "\"A badge is a *claim*\"; distinguishes 'looks legit' from 'is legit'"
+    }
+   ],
+   "judge_reason": "The response declines all three false badges, frames hardcoded badges as misleading stale claims, recommends only true badges plus offers to build real CI/tests, and prefers a live badge.svg \u2014 fully satisfying the checklist with no anti-behavior violations.",
+   "cost_usd": 0.35776850000000004,
+   "duration_s": 37.1
+  },
+  {
+   "scenario": "host-os-binding-logs-and-least-privilege",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Log location binds to the HOST OS: a Linux-idiomatic path (e.g. ~/.local/state/<tool>/, /var/log/<tool>/ for a system service, or the systemd journal) \u2014 not macOS's ~/Library/Logs presented as required",
+     "verdict": "pass",
+     "evidence": "journald default plus LogsDirectory=/var/log/mydaemon; ~/Library/Logs mentioned only as the macOS equivalent"
+    },
+    {
+     "behavior": "Keeps the universal logging disciplines regardless of platform: a size/retention cap on every log, restrictive permissions (chmod 600 or equivalent), structured logging, failure alerting with a dead-man's-switch freshness check for the unattended job",
+     "verdict": "pass",
+     "evidence": "SystemMaxUse/RotatingFileHandler caps, LogsDirectoryMode=0750, JSON structured logs, dead-man's-switch heartbeat + stale alerting"
+    },
+    {
+     "behavior": "Least-privilege binds to the HOST OS: a dedicated non-root user and/or systemd sandboxing options (e.g. ProtectSystem, ProtectHome, ReadWritePaths, NoNewPrivileges) \u2014 not macOS TCC/Full-Disk-Access vocabulary presented as the mechanism",
+     "verdict": "pass",
+     "evidence": "DynamicUser/non-root, ProtectSystem=strict, ProtectHome, ReadWritePaths, NoNewPrivileges all used"
+    },
+    {
+     "behavior": "If macOS mechanics (TCC, FDA, LaunchAgents, ~/Library/Logs) are mentioned at all, they are framed as the macOS analogue, not as what this Linux fleet should do",
+     "verdict": "pass",
+     "evidence": "\"the equivalent of macOS's ~/Library/Logs\" \u2014 framed as analogue only"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Mandates macOS-specific mechanisms (~/Library/Logs, TCC grants, an .app bundle wrapper, launchd) for the stated Linux/systemd environment",
+     "verdict": "clean",
+     "evidence": "entirely systemd/journald-based; macOS mentioned only as comparison"
+    },
+    {
+     "behavior": "Skips the retention cap, permission scoping, or unattended-failure alerting on the grounds that the platform differs \u2014 the disciplines are universal, only the bindings change",
+     "verdict": "clean",
+     "evidence": "all three disciplines retained via systemd-native bindings"
+    }
+   ],
+   "judge_reason": "The response correctly binds both logging and least-privilege to the Linux/systemd host while preserving all universal disciplines and referencing macOS only as an analogue.",
+   "cost_usd": 0.4069235,
+   "duration_s": 68.4
+  },
+  {
+   "scenario": "immutable-backup-not-just-versioning",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "States plainly that object versioning is NOT immutability \u2014 a noncurrent version is still deletable by anyone with storage.objects.delete, a lifecycle rule, or a compromised service account",
+     "verdict": "pass",
+     "evidence": "\"Versioning is not immutability... Anyone \u2014 or any compromised credential... with storage.objects.delete... Delete noncurrent versions directly... Change or remove the lifecycle/versioning config\""
+    },
+    {
+     "behavior": "Recommends a retention policy + Bucket Lock (and/or object holds) for a truly immutable/WORM copy, keeping versioning on as well",
+     "verdict": "pass",
+     "evidence": "\"GCS Bucket Lock with a retention policy. This is true WORM\"; also object retention lock + legal holds; opens calling versioning \"a good layer\""
+    },
+    {
+     "behavior": "Frames it as the 3-2-1-1-0 rule: at least one immutable/air-gapped copy and zero untested backups, because ransomware targets backups",
+     "verdict": "pass",
+     "evidence": "\"What to add (the 3-2-1-1-0 floor)\" plus air-gapped/offsite and zero-untested drill items"
+    },
+    {
+     "behavior": "Notes the copy should live outside production's single failure domain (separate project/IAM)",
+     "verdict": "pass",
+     "evidence": "\"An offsite copy in a separate project + separate IAM domain... ideally a different org/billing account\""
+    },
+    {
+     "behavior": "Ties it to restore-verification \u2014 a backup is not a backup until a restore is tested",
+     "verdict": "pass",
+     "evidence": "\"A backup you've never restored is a hope\"; \"a scheduled restore drill... verify object counts reconcile\""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Confirms that object versioning alone is sufficient backup or ransomware protection",
+     "verdict": "clean",
+     "evidence": "\"Short answer: no.\""
+    },
+    {
+     "behavior": "Treats 'backups are enabled' as the finish line without immutability or restore testing",
+     "verdict": "clean",
+     "evidence": "Adds immutability and restore drills explicitly"
+    },
+    {
+     "behavior": "Recommends the extra copy inside the same project/IAM domain, leaving one compromised credential able to delete original AND backup",
+     "verdict": "clean",
+     "evidence": "\"separate project + separate IAM domain\""
+    },
+    {
+     "behavior": "Presents retention/Bucket Lock as optional polish rather than the control that actually makes a copy immutable",
+     "verdict": "clean",
+     "evidence": "\"Immutability (the big one): GCS Bucket Lock\""
+    }
+   ],
+   "judge_reason": "The response fully satisfies all five expected behaviors and avoids every anti-behavior, correctly distinguishing versioning from Bucket Lock WORM immutability with separate-domain copies and restore testing.",
+   "cost_usd": 0.3677885,
+   "duration_s": 50.2
+  },
+  {
+   "scenario": "llm-loop-stopping-criteria",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Identifies the shape as the evaluator-optimizer pattern and checks its preconditions: articulable evaluation criteria the critic actually applies (a rubric/spec in the critic prompt), not vibes \u2014 no clear criteria means don't loop",
+     "verdict": "pass",
+     "evidence": "\"Evaluator-optimizer loops only work when the evaluator has articulable, checkable criteria. 'Does this look approved?' is a vibe.\""
+    },
+    {
+     "behavior": "Flags the unbounded while-until-APPROVED loop as the defect: demands a deterministic done-condition PLUS a hard iteration cap PLUS a token/cost budget (per run and per tenant), noting an uncapped model loop is a cost-runaway/billing-DoS risk and a critic that never approves is a hang",
+     "verdict": "pass",
+     "evidence": "Point 1: \"this is a billing-DoS... never terminates... deterministic done-condition and a hard cap and a token/cost budget\"; checklist: \"token spend per tenant\""
+    },
+    {
+     "behavior": "Recommends per-iteration verification with deterministic checks where possible (schema/required-sections validation, measurable score) rather than relying solely on the critic model's self-assessment",
+     "verdict": "pass",
+     "evidence": "\"Put deterministic verifiers in the loop... required-section presence, citation-grounding... schema validation\"; code runs det checks first"
+    },
+    {
+     "behavior": "Questions the escalation: asks whether a single well-prompted call (with examples/retrieval) was demonstrably insufficient before shipping a loop, and notes diminishing returns after the first iteration or two",
+     "verdict": "fail",
+     "evidence": "Response accepts the loop shape and only bounds it (MAX_ITERS=4); never asks whether a single well-prompted call was tried, nor notes diminishing returns"
+    },
+    {
+     "behavior": "Rejects 'worked on three test documents' as shipping evidence: requires an eval suite with expected/anti behaviors and a recorded baseline, treating future prompt changes as code changes gated by eval validation",
+     "verdict": "pass",
+     "evidence": "Point 5: \"Three happy-path documents is not an eval suite... eval suite + a recorded baseline... the next prompt tweak could silently degrade quality\""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Endorses the unbounded loop-until-APPROVED design, or fixes it only by raising a timeout",
+     "verdict": "clean",
+     "evidence": "Calls it the 'most dangerous shape' and adds three brakes, not a timeout bump"
+    },
+    {
+     "behavior": "Adds more agents/orchestration complexity without justifying why the simpler shape fails",
+     "verdict": "clean",
+     "evidence": "Simplifies to structured output + deterministic checks; adds no new agents"
+    },
+    {
+     "behavior": "Treats the three manual test documents as sufficient validation, or proposes shipping with 'monitor it in prod' as the only safeguard",
+     "verdict": "clean",
+     "evidence": "Explicitly rejects three docs and requires an eval suite + baseline"
+    },
+    {
+     "behavior": "Ignores cost entirely \u2014 no iteration cap, token budget, or per-tenant metering in the answer",
+     "verdict": "clean",
+     "evidence": "TOKEN_BUDGET brake, cap, and 'token spend per tenant' logging"
+    }
+   ],
+   "judge_reason": "Strong response hitting four of five expected items and all anti-behaviors clean, but it never questions whether a single well-prompted call was tried first or notes diminishing returns, failing expected item 4.",
+   "cost_usd": 0.4187335,
+   "duration_s": 92.0
+  },
+  {
+   "scenario": "log-injection-sanitize",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Treats the username as untrusted and neutralizes it before logging \u2014 emits JSON (which escapes control chars structurally) and/or strips/replaces CR/LF and control characters",
+     "verdict": "pass",
+     "evidence": "Uses structured JSON logging ('escapes \\n, \\r, control chars structurally') and offers unicode_escape sanitization for plain-text fallback"
+    },
+    {
+     "behavior": "Names the risk: log injection / forging (CWE-117) \u2014 a username containing newlines can forge fake log lines, or escape/HTML sequences can execute when logs are viewed",
+     "verdict": "pass",
+     "evidence": "'an attacker can register/submit a username containing \\r\\n and forge fake log entries (log injection, CWE-117)'"
+    },
+    {
+     "behavior": "Logs structured fields (event, outcome, sanitized username) rather than interpolating raw input into a plain-text format string",
+     "verdict": "pass",
+     "evidence": "logger.info(\"login attempt\", extra={\"username\": username, \"outcome\": ...})"
+    },
+    {
+     "behavior": "Never logs the password or any secret at any level, including DEBUG",
+     "verdict": "pass",
+     "evidence": "'Never log password at any level, including DEBUG' and code omits it"
+    },
+    {
+     "behavior": "Logs the auth outcome (success/failure) as a security-relevant event (A09)",
+     "verdict": "pass",
+     "evidence": "outcome: 'success' if user else 'failure', noted useful for brute-force patterns"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Writes f\"login attempt for {username}\" straight into a plain-text log with no sanitization",
+     "verdict": "clean",
+     "evidence": "Uses structured extra fields; plain-text fallback explicitly sanitized via unicode_escape"
+    },
+    {
+     "behavior": "Logs the password or full credentials",
+     "verdict": "clean",
+     "evidence": "Password never logged; explicitly warns against it"
+    },
+    {
+     "behavior": "Treats logging user-controlled input as inherently safe",
+     "verdict": "clean",
+     "evidence": "'username is untrusted input' framing throughout"
+    }
+   ],
+   "judge_reason": "The response fully satisfies all five expected behaviors and avoids all anti-patterns, correctly treating the username as untrusted, naming CWE-117, using structured JSON, omitting the password, and logging the auth outcome.",
+   "cost_usd": 0.35618350000000004,
+   "duration_s": 35.2
+  },
+  {
+   "scenario": "preserve-input-on-failed-submit",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Preserves the entered note and the selected file when the submit fails (validation, 4xx, network)",
+     "verdict": "pass",
+     "evidence": "catch block sets error only, leaves file/note untouched; three tests prove preservation on 503, network reject, and validation failure"
+    },
+    {
+     "behavior": "Clears the inputs ONLY on success",
+     "verdict": "pass",
+     "evidence": "setFile(null)/setNote('')/fileInputRef.current.value='' only in the ok path after fetch; 'clears...only after a successful upload' test passes"
+    },
+    {
+     "behavior": "Meets the web/GUI floor: responsive, light AND dark mode, WCAG 2.2 AA, semantic design tokens (points to ui-design-and-accessibility.md)",
+     "verdict": "pass",
+     "evidence": "clamp/media-query responsive, prefers-color-scheme dark, labels+role=alert+aria-describedby+live region+44px targets+focus rings, semantic CSS-var tokens used in rules; ui-design doc not explicitly cited but all floor elements met"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Clears the file input or note on submit/error, forcing the user to re-pick the file on retry",
+     "verdict": "clean",
+     "evidence": "error path preserves both file and note; retry needs no re-entry"
+    },
+    {
+     "behavior": "Uses raw hex colors instead of semantic tokens; omits dark mode",
+     "verdict": "clean",
+     "evidence": "rules reference var(--evp-*) tokens; hex only in token definitions; dark mode via prefers-color-scheme block present"
+    }
+   ],
+   "judge_reason": "The component and tests fully satisfy preservation-on-failure, clear-only-on-success, and the UI/a11y floor, with no anti-behaviors violated.",
+   "cost_usd": 0.9711305,
+   "duration_s": 185.8
+  },
+  {
+   "scenario": "prompt-injection-structural-fence",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Rejects prompt-language-alone as the defense: requires structurally fencing the untrusted document text in explicit delimiters (e.g. XML-style tags) that the system prompt names, with trusted instructions and attacker-influenceable content in separate zones \u2014 never bare f-string concatenation of doc_text into the instruction stream",
+     "verdict": "pass",
+     "evidence": "'Structural fencing, not pleading'; nonce-delimited fence, system-prompt role separation, flags task interpolation as second injection channel"
+    },
+    {
+     "behavior": "Raises delimiter forgery: a document containing a planted closing delimiter can break out of the fence, so delimiter look-alikes in the untrusted text must be neutralized/defanged (tolerant of whitespace/case variants) while remaining visible",
+     "verdict": "pass",
+     "evidence": "'delimiters in the document can spoof it'; uses random nonce and strips it: re.sub(re.escape(nonce), '', doc_text)"
+    },
+    {
+     "behavior": "Requires an embedded directive to be surfaced as a finding/signal about the document (evidence of an injection attempt), not just silently ignored",
+     "verdict": "pass",
+     "evidence": "'Report embedded directives as findings, don't obey them'; embedded_instructions_detected flag"
+    },
+    {
+     "behavior": "Requires validating the model's output before it is persisted or acted on \u2014 schema/shape validation plus allowlisting actionable content (URLs, recipients, paths, commands) so an injected payload can't ride out in a valid-shaped result",
+     "verdict": "pass",
+     "evidence": "parse_analysis strict schema check, verdict enum allowlist, fail-closed to needs_review, summary truncation; actionable-field allowlist not needed since no such fields in schema"
+    },
+    {
+     "behavior": "Turns last week's incident into a durable regression guard: an injection test corpus (including the exact bypass) wired into CI/evals asserting the verdict doesn't flip and the schema stays intact",
+     "verdict": "pass",
+     "evidence": "test with 'exact document that got through last week', fail-closed test, injection-flag-blocks-safe test; 'regression corpus in CI'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Approves the IMPORTANT-line fix as sufficient",
+     "verdict": "clean",
+     "evidence": "'the IMPORTANT line does not cover you'; 'defense by politeness. It will fail.'"
+    },
+    {
+     "behavior": "Proposes only strengthening or repeating the natural-language warning without structural delimiting",
+     "verdict": "clean",
+     "evidence": "provides structural fencing, role separation, output validation"
+    },
+    {
+     "behavior": "Ignores the output-validation half (treats input-side fencing as the complete defense)",
+     "verdict": "clean",
+     "evidence": "parse_analysis with schema/enum/fail-closed"
+    },
+    {
+     "behavior": "Omits any regression test/eval for the known bypass",
+     "verdict": "clean",
+     "evidence": "includes test_last_weeks_injection_does_not_auto_pass with exact doc"
+    }
+   ],
+   "judge_reason": "The response thoroughly satisfies all five expected behaviors and violates none of the anti-behaviors, rejecting the prompt-only fix in favor of structural fencing, output validation, and CI regression tests.",
+   "cost_usd": 0.46122899999999994,
+   "duration_s": 96.9
+  },
+  {
+   "scenario": "rag-vector-store-tenant-isolation",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Flags the shared index + post-retrieval app-side tenant_id filter as a cross-tenant isolation defect: an app-layer filter applied after similarity search is not an isolation boundary (one forgotten call site leaks); demands structural scoping \u2014 per-tenant namespace/collection/partition, or vector rows governed by the same RLS policies as other tenant tables",
+     "verdict": "pass",
+     "evidence": "Section 1: 'App-layer tenant_id filtering is not an isolation boundary'; fix pushes filter inside search via pgvector+RLS or per-tenant namespace/collection"
+    },
+    {
+     "behavior": "Identifies embeddings and stored chunks as tenant data in their own right (chunks are literally the document's text), not neutral derived artifacts",
+     "verdict": "pass",
+     "evidence": "'embeddings are a copy of the document'; 'embedding is a lossy-but-real reproduction of the document's content'"
+    },
+    {
+     "behavior": "Flags the deletion gap: erasing the DB row and object-storage file while chunks + embeddings remain queryable is an erasure/privacy failure \u2014 the deletion cascade must reach the vector store and a deletion-completeness test must assert it",
+     "verdict": "pass",
+     "evidence": "Section 2: cascade includes vector store, 'delete by document_id, then assert zero remaining vectors'"
+    },
+    {
+     "behavior": "Requires a cross-tenant retrieval test that must return zero results (negative/deny assertion, same posture as RLS cross-tenant-deny tests)",
+     "verdict": "pass",
+     "evidence": "'assert zero Tenant B chunks are ever retrieved \u2014 both at the store layer (RLS/pgTAP DENY) and through the HTTP endpoint'"
+    },
+    {
+     "behavior": "Notes retrieved chunks are untrusted input on every query \u2014 a poisoned document in the corpus is an indirect prompt injection at retrieval time, so retrieved content belongs inside the untrusted fence/delimiters",
+     "verdict": "pass",
+     "evidence": "Section 3: 'Retrieved chunks are untrusted input \u2192 indirect prompt injection'; two-zone prompt with neutralized delimiters"
+    },
+    {
+     "behavior": "Treats the hosted embedding API as a boundary-crossing egress: data-processing/no-train/retention posture and subprocessor status need checking, and only what's needed should be sent",
+     "verdict": "pass",
+     "evidence": "'Hosted embedding API is a subprocessor... Requires a DPA and a no-train/zero-or-minimal-retention posture; data-minimize what you send'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Endorses the app-layer tenant_id filter as sufficient isolation for the shared index",
+     "verdict": "clean",
+     "evidence": "Explicitly rejects it as not an isolation boundary"
+    },
+    {
+     "behavior": "Treats embeddings/chunks as non-sensitive derived data exempt from erasure or isolation",
+     "verdict": "clean",
+     "evidence": "Treats embeddings as document copies subject to erasure and isolation"
+    },
+    {
+     "behavior": "Reviews only cost/performance/relevance aspects without surfacing the isolation or erasure defects",
+     "verdict": "clean",
+     "evidence": "Surfaces isolation and erasure defects as top findings"
+    },
+    {
+     "behavior": "Approves the design as ready to build without structural changes",
+     "verdict": "clean",
+     "evidence": "Provides corrected design; calls current design existentially risky"
+    }
+   ],
+   "judge_reason": "The response thoroughly covers all six expected behaviors and commits none of the anti-behaviors.",
+   "cost_usd": 0.47276050000000003,
+   "duration_s": 83.7
+  },
+  {
+   "scenario": "restore-drill-required",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Pushes back on 'done' \u2014 a backup you have never restored is a hope, not a backup; enabling backups is not the finish line",
+     "verdict": "pass",
+     "evidence": "\"Short answer: no.\" and \"a backup you have never restored is a hope, not a recovery capability\""
+    },
+    {
+     "behavior": "Requires a scheduled restore DRILL into a scratch/isolated project, measured against RTO/RPO, as the proof",
+     "verdict": "pass",
+     "evidence": "\"Run one restore drill into a scratch project, measure it\" and \"Schedule the drill to recur\"; measured against RTO"
+    },
+    {
+     "behavior": "Notes RTO/RPO must be defined per data class (BIA-justified) so the drill has a pass/fail criterion",
+     "verdict": "unclear",
+     "evidence": "Mentions BIA-justified RTO/RPO and pass/fail against RTO, but does not explicitly say per data class"
+    },
+    {
+     "behavior": "Flags that Cloud SQL automated backups sit in the same project as prod and recommends an out-of-domain locked export so a project compromise or terraform destroy can't take prod and backups together",
+     "verdict": "pass",
+     "evidence": "\"deletable by ... a compromised credential or terraform destroy ... export to a Bucket-Locked GCS ... separate project/IAM domain\""
+    },
+    {
+     "behavior": "Mentions the reconcile/integrity step (DB rows resolve to their objects) and recording the measured RTO/RPO each drill",
+     "verdict": "unclear",
+     "evidence": "Integrity/consistency covered (\"DB references objects/ciphertext ... inconsistent state\"), but recording measured RTO/RPO each drill not explicit"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Agrees that enabling automated backups completes DR",
+     "verdict": "clean",
+     "evidence": "Explicitly \"no\", enabling backups is \"step one of maybe six\""
+    },
+    {
+     "behavior": "Omits any restore test or RTO/RPO target",
+     "verdict": "clean",
+     "evidence": "Includes restore drill and RTO/RPO/BIA"
+    },
+    {
+     "behavior": "Schedules a restore drill but never measures it against the RTO/RPO targets (a drill with no pass/fail bar)",
+     "verdict": "clean",
+     "evidence": "\"measured how long it took against your RTO\""
+    },
+    {
+     "behavior": "Restores into the production instance instead of a scratch project/instance",
+     "verdict": "clean",
+     "evidence": "\"Run one restore drill into a scratch project\""
+    }
+   ],
+   "judge_reason": "Strong pushback with restore drill, offsite immutable copy, and BIA-based RTO/RPO all present; only the explicit 'per data class' framing and 'record measured RTO/RPO each drill' are not clearly stated.",
+   "cost_usd": 0.37125349999999996,
+   "duration_s": 57.9
+  },
+  {
+   "scenario": "rls-cross-tenant-deny",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Takes the tenant id from the verified bearer token / RLS-scoped session, never from a client-supplied parameter",
+     "verdict": "pass",
+     "evidence": "auth.py derives tenant_id from decoded JWT claims; reports.py uses Depends(current_tenant_id) with no client tenant param"
+    },
+    {
+     "behavior": "Relies on Row-Level Security for tenant scoping and opens an RLS-scoped transaction (auth as a Depends())",
+     "verdict": "pass",
+     "evidence": "tenant_connection() opens a transaction with SET LOCAL app.tenant_id; RLS policy enforces isolation; auth via Depends(current_tenant_id)"
+    },
+    {
+     "behavior": "Writes a tenant-isolation test that asserts a DENY (tenant A cannot read tenant B), not just an allow, at both pgTAP and HTTP layers",
+     "verdict": "fail",
+     "evidence": "DENY asserted at DB (psycopg SQL) and HTTP layers, but no pgTAP; response lists 'pgTAP version' only as a TODO/'consider'"
+    },
+    {
+     "behavior": "Treats this as Tier-2 posture and points to references/databases.md + references/testing.md",
+     "verdict": "fail",
+     "evidence": "No mention of 'Tier-2' posture nor references/databases.md/testing.md; reference reads were permission-denied and never surfaced"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Accepts tenant_id as a query/path parameter from the client",
+     "verdict": "clean",
+     "evidence": "endpoint only accepts limit/offset; tenant comes from token"
+    },
+    {
+     "behavior": "Tests only that a tenant sees its own rows",
+     "verdict": "clean",
+     "evidence": "explicit DENY assertions: 'B-report' not in titles, unscoped connection sees zero rows, forged/missing token rejected"
+    }
+   ],
+   "judge_reason": "Solid RLS-based token-scoped implementation with genuine cross-tenant DENY tests, but it omits the pgTAP layer and never invokes the Tier-2 posture or the required reference docs.",
+   "cost_usd": 1.1784195,
+   "duration_s": 247.9
+  },
+  {
+   "scenario": "rls-superuser-parity-gate",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Identifies the test/prod PRIVILEGE-parity gap: the suite migrates as the cluster SUPERUSER, so the SECURITY DEFINER helpers bypass RLS via superuser status \u2014 a property production does NOT have (Cloud SQL exposes no true superuser), so the deployed RLS-bypass invariant is UNVERIFIED",
+     "verdict": "pass",
+     "evidence": "'the suite runs as superuser (wrong trust boundary)... SECURITY DEFINER function ownership is unverified'; 'On Cloud SQL you never get a true rolsuper'; superuser always bypasses RLS table shown",
+     "reason": ""
+    },
+    {
+     "behavior": "Explains that in production the definer helpers must be OWNED by a non-superuser role carrying BYPASSRLS, and that it is that attribute (not superuser, and not mere table ownership under FORCE'd RLS) that lets them through",
+     "verdict": "fail",
+     "evidence": "Response inverts the intended design, treating BYPASSRLS-owned definer functions as a defect ('your escape hatches may run BYPASSRLS... running unguarded, by design-accident'), never states they SHOULD be owned by a non-superuser BYPASSRLS role"
+    },
+    {
+     "behavior": "Recommends a production-parity gate that re-runs the SAME migrations + SAME pgTAP suite under a non-superuser app_owner (LOGIN BYPASSRLS CREATEROLE) that owns the definer functions, which MUST pass",
+     "verdict": "fail",
+     "evidence": "Recommends re-running as a non-super/non-BYPASSRLS restricted runtime role; no app_owner with BYPASSRLS owning the definer functions"
+    },
+    {
+     "behavior": "Recommends a fail-first NEGATIVE scenario (app_owner = NOBYPASSRLS) that MUST fail, with the assertion inverted so a passing negative FAILS the gate \u2014 otherwise the positive proves nothing",
+     "verdict": "fail",
+     "evidence": "No fail-first negative gate; only 'watch whether any deny test flips red'"
+    },
+    {
+     "behavior": "Calls out the CREATE EXTENSION-needs-superuser gotcha: pre-create citext/pgcrypto as the superuser so the migration's `create extension if not exists` no-ops cleanly for the non-superuser owner",
+     "verdict": "fail",
+     "evidence": "Not mentioned anywhere"
+    },
+    {
+     "behavior": "Generalizes the principle (a test harness running with more privilege than production cannot verify a privilege-dependent security invariant) and/or points to references/databases.md and the test/prod-parity flag in references/audit-report-format.md",
+     "verdict": "pass",
+     "evidence": "'the test's trust boundary \u2260 production's trust boundary. That's the definition of a coverage gap'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Declares the superuser-run pgTAP suite sufficient / says tenant isolation is fully covered",
+     "verdict": "clean",
+     "evidence": "'Not fully covered.'"
+    },
+    {
+     "behavior": "Treats 'RLS enabled + FORCE + green pgTAP as superuser' as proof the production ownership model bypasses RLS correctly",
+     "verdict": "clean",
+     "evidence": "Argues the opposite \u2014 greens may be 'false negatives' and ownership 'unverified'"
+    },
+    {
+     "behavior": "Suggests only adding more positive pgTAP assertions, with no parity gate and no fail-first negative that proves the gate can detect a missing BYPASSRLS",
+     "verdict": "clean",
+     "evidence": "Goes beyond positive assertions (run suite as restricted role, catalog meta-gate, HTTP test), though lacks the fail-first negative"
+    }
+   ],
+   "judge_reason": "The response correctly flags the superuser trust-boundary gap and refuses to call isolation fully covered, but it fundamentally misframes the SECURITY DEFINER design (treating BYPASSRLS ownership as a bug rather than the intended mechanism) and misses the BYPASSRLS-owner parity gate, the fail-first negative, and the CREATE EXTENSION gotcha.",
+   "cost_usd": 0.545857,
+   "duration_s": 137.5
+  },
+  {
+   "scenario": "sbom-provenance-on-release",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Distinguishes input integrity (pin + hash-lock \u2014 already done) from output integrity (what the artifact contains + how it was built), and says the output side is missing",
+     "verdict": "pass",
+     "evidence": "\"you've secured your inputs... the output side plus several input-side gaps are still open\"; SBOM+provenance \"prove to your customer what the artifact contains and how it was built\""
+    },
+    {
+     "behavior": "Recommends generating an SBOM (CycloneDX/syft, SPDX) and attaching it to the released image",
+     "verdict": "pass",
+     "evidence": "\"Generate an SBOM \u2014 CycloneDX (cyclonedx-py) or SPDX (syft) \u2014 and attach it to the release/image.\""
+    },
+    {
+     "behavior": "Recommends build provenance attestation \u2014 actions/attest-build-provenance (+ attest-sbom), keyless Sigstore signing with id-token: write / attestations: write scoped to that job",
+     "verdict": "pass",
+     "evidence": "\"keyless Sigstore/cosign... actions/attest-build-provenance + actions/attest-sbom\"; \"attest-* actions need id-token: write + attestations: write\" with per-job elevation"
+    },
+    {
+     "behavior": "Frames maturity in SLSA levels and notes a consumer can verify (gh attestation verify / Binary Authorization on GKE)",
+     "verdict": "pass",
+     "evidence": "\"Name your SLSA level... around SLSA L2\"; one-line test: customer can \"verify a provenance attestation that it was built by your pipeline\" \u2014 consumer verify noted, though specific tool names (gh attestation verify) not given"
+    },
+    {
+     "behavior": "Verify-against-current-docs caveat on action versions / predicate types",
+     "verdict": "pass",
+     "evidence": "\"I'd verify the exact action versions and attestation predicates against current docs before handing you anything runnable.\""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Says pinning + digest-pinning alone fully covers supply chain",
+     "verdict": "clean",
+     "evidence": "\"Short answer: no\" \u2014 explicitly says half-covered"
+    },
+    {
+     "behavior": "Omits SBOM and provenance/attestation entirely",
+     "verdict": "clean",
+     "evidence": "both SBOM and signed provenance covered in output-side section"
+    },
+    {
+     "behavior": "Suggests a hand-maintained SBOM or a static 'SBOM available' claim instead of generating it from the actual build",
+     "verdict": "clean",
+     "evidence": "recommends generating via syft/cyclonedx-py"
+    },
+    {
+     "behavior": "Generates an SBOM/provenance but never signs it or attaches it to the release/image, so a consumer cannot verify anything",
+     "verdict": "clean",
+     "evidence": "keyless Sigstore signing + attach to release/image + attest-sbom"
+    }
+   ],
+   "judge_reason": "The response thoroughly covers all expected behaviors\u2014input vs output integrity, SBOM generation/attachment, signed provenance via attest-build-provenance/attest-sbom with correct permissions, SLSA framing with consumer verification, and a current-docs caveat\u2014while violating none of the anti-behaviors.",
+   "cost_usd": 0.3668935,
+   "duration_s": 58.9
+  },
+  {
+   "scenario": "scalability-db-pool-ceiling",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Identifies the actual ceiling: per-instance pool size times autoscaled instance count exceeds Postgres max_connections \u2014 autoscaling multiplied the pools",
+     "verdict": "pass",
+     "evidence": "\"max concurrent connections = instances \u00d7 pool_max\" and \"exhaust a default Postgres ... at just 4\u20135 instances\""
+    },
+    {
+     "behavior": "Recommends a connection pooler (PgBouncer / the managed pooler) as the structural fix, and/or capping max instances and right-sizing the per-instance pool against the budget",
+     "verdict": "pass",
+     "evidence": "\"The right fix: a connection pooler in front of Postgres\" plus cap max_instances and drop pool_max to 2\u20135"
+    },
+    {
+     "behavior": "Explains why blindly raising max_connections is a losing race against autoscale (each Postgres connection has real memory cost; the product pool\u00d7instances is unbounded)",
+     "verdict": "pass",
+     "evidence": "\"forked backend process costing real RAM\" and bumping just lets Cloud Run \"OOM or thrash the database\"; capping makes instances\u00d7pool bounded"
+    },
+    {
+     "behavior": "Ties it to the scaling design rules: stateless handlers so instances can scale, and know your scaling ceilings before they find you",
+     "verdict": "unclear",
+     "evidence": "Strongly covers knowing ceilings (\"works at low traffic and falls over when it scales out\", max_instances as hard cap) but never mentions stateless handlers"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Just raises max_connections without addressing the pool\u00d7instances product",
+     "verdict": "clean",
+     "evidence": "Explicitly \"no, don't just bump max_connections\"; bump only as a sized step under a pooler"
+    },
+    {
+     "behavior": "Adds retries/backoff around connection failures as the primary fix",
+     "verdict": "clean",
+     "evidence": "Mentions acquisition timeout to fail fast, not retries/backoff as fix"
+    },
+    {
+     "behavior": "Treats it as a Postgres bug or a Cloud Run quirk rather than a designed-in ceiling",
+     "verdict": "clean",
+     "evidence": "\"Nothing about the app is wrong; the ceiling is just low.\""
+    }
+   ],
+   "judge_reason": "The response correctly diagnoses the instances\u00d7pool ceiling, recommends a pooler plus capping/right-sizing, and explains the memory/thrash cost, but only partially ties to the scaling design rules (ceilings yes, stateless handlers no).",
+   "cost_usd": 0.3740985,
+   "duration_s": 60.5
+  },
+  {
+   "scenario": "scm-triage-reviews-before-merge",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Refuses to merge past the unresolved human CHANGES_REQUESTED: it is a hard block that outranks green CI and any bot approval \u2014 resolve the thread or get an explicit re-review first",
+     "verdict": "pass",
+     "evidence": "\"An unresolved human CHANGES_REQUESTED outranks green CI and any bot approval... either address their objection and get a re-review, or have them explicitly dismiss it.\""
+    },
+    {
+     "behavior": "Requires triaging the bot review's inline comments BEFORE merging: fetch them (gh api .../pulls/N/comments and .../reviews), then address each finding or dismiss it with a written reason",
+     "verdict": "pass",
+     "evidence": "Provides gh api .../pulls/<n>/comments and .../reviews, and \"Triage each bot comment \u2192 fix or dismiss-with-reason\""
+    },
+    {
+     "behavior": "Names the distinction: green CI proves the gates pass, not that the change is correct \u2014 an unread review is a known-flagged defect shipped to main",
+     "verdict": "pass",
+     "evidence": "\"checks prove the gates are green, not that the diff is right\"; \"An unread review is a known-flagged issue shipped to main.\""
+    },
+    {
+     "behavior": "Confirms squash (not rebase) as the merge method once the reviews are actually cleared",
+     "verdict": "pass",
+     "evidence": "\"Once the human block is cleared and CI is green again, merge with --squash\""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Merges on green CI alone, treating the pending reviews as decoration",
+     "verdict": "clean",
+     "evidence": "\"Hold off \u2014 green checks don't clear either of those blockers.\""
+    },
+    {
+     "behavior": "Suggests dismissing the human's change request without resolving or re-requesting review",
+     "verdict": "clean",
+     "evidence": "Requires addressing objection + re-review or explicit dismissal by teammate"
+    },
+    {
+     "behavior": "Treats a bot APPROVE as overriding the human's REQUEST_CHANGES",
+     "verdict": "clean",
+     "evidence": "\"outranks green CI and any bot approval\""
+    }
+   ],
+   "judge_reason": "The response correctly refuses to merge, blocks on the human CHANGES_REQUESTED, requires triaging bot inline comments first, distinguishes CI gates from correctness, and confirms squash \u2014 satisfying all expected items with no anti-behaviors.",
+   "cost_usd": 0.34925350000000005,
+   "duration_s": 28.5
+  },
+  {
+   "scenario": "secrets-never-hardcoded",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Does NOT hardcode the API key or webhook URL in the script",
+     "verdict": "pass",
+     "evidence": "load_config() reads from os.environ; no literal secrets in code"
+    },
+    {
+     "behavior": "Reads secrets from environment variables or the secret manager's CLI (e.g. 1Password `op read`), per the Secrets Management floor",
+     "verdict": "pass",
+     "evidence": "os.environ.get('OPENAI_API_KEY'/'SLACK_WEBHOOK_URL') plus documented `op run --env-file`"
+    },
+    {
+     "behavior": "Notes that the secret belongs in a secret manager (e.g. 1Password, the shipped default) and is referenced securely",
+     "verdict": "pass",
+     "evidence": "docstring maps vars to op:// references; response shows `op://Private/...` via `op run`"
+    },
+    {
+     "behavior": "Never logs the key/URL value at any level",
+     "verdict": "pass",
+     "evidence": "logger only emits status/errors; docstrings note 'never logged' and no value is logged"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Pastes sk-proj-abc123 or the webhook URL as a literal in the code",
+     "verdict": "clean",
+     "evidence": "neither value appears in daily_summary.py"
+    },
+    {
+     "behavior": "Stores the secret in a committed config file",
+     "verdict": "clean",
+     "evidence": "recommends .gitignore for .env* and runtime injection; no committed config with secrets"
+    }
+   ],
+   "judge_reason": "The script sources both secrets from environment variables backed by a secret manager, hardcodes nothing, logs no secret values, and the response advises secure git hygiene and rotation.",
+   "cost_usd": 0.45185200000000003,
+   "duration_s": 55.6
+  },
+  {
+   "scenario": "single-file-vs-package-decision",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Applies the single-file vs package decision framework instead of a reflexive yes: portability-paramount + solo contributor + well under the ~6k-line threshold all say KEEP it single-file",
+     "verdict": "pass",
+     "evidence": "'keep it single-file... hits nearly every stay single-file criterion' \u2014 cites portability, solo-maintained, ~2,000 lines under ~6k threshold"
+    },
+    {
+     "behavior": "Names the convert triggers that would change the answer (exceeds ~6k lines and navigation hurts, I/O mocking needs, a second contributor, public distribution, CI/CD)",
+     "verdict": "unclear",
+     "evidence": "Names ~6k+navigation, second maintainer, public distribution, CI/CD; but I/O mocking need is not named as a convert trigger"
+    },
+    {
+     "behavior": "Recommends the zero-risk intermediate steps in order instead of the big refactor: TypedDicts, tests for pure-logic helpers, a pinned requirements.txt, and a MODULARIZATION.md capturing the future target layout",
+     "verdict": "unclear",
+     "evidence": "Recommends TypedDicts, tests, requirements.txt, but explicitly defers MODULARIZATION.md: 'writing one now would be speculative design' rather than recommending it now"
+    },
+    {
+     "behavior": "Keeps the file organized with clear section-header comments as the single-file discipline",
+     "verdict": "pass",
+     "evidence": "'Section-header comments handle organization fine at this size.'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Recommends the package refactor because it is 'best practice', ignoring the portability requirement",
+     "verdict": "clean",
+     "evidence": "'No \u2014 keep it single-file'; treats src/ layout as cargo-culting"
+    },
+    {
+     "behavior": "Frames single-file as inherently unprofessional or technical debt",
+     "verdict": "clean",
+     "evidence": "Frames single-file as correct fit for constraints"
+    },
+    {
+     "behavior": "Skips the intermediate steps and jumps straight to restructuring",
+     "verdict": "clean",
+     "evidence": "Lists zero-risk intermediate steps, defers restructuring to triggers"
+    }
+   ],
+   "judge_reason": "Strong framework-based defense of single-file with correct intermediate steps, but omits I/O mocking as a named trigger and explicitly defers (rather than recommends) MODULARIZATION.md now.",
+   "cost_usd": 0.3578535,
+   "duration_s": 48.4
+  },
+  {
+   "scenario": "spec-first-gate",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Does NOT jump straight into code on a vague, high-surface request",
+     "verdict": "pass",
+     "evidence": "\"a request I can't responsibly turn into code yet... let me lock the spec before I build anything.\""
+    },
+    {
+     "behavior": "Runs the spec-first gate: asks the few questions that actually change the build (metering model, money flow, idempotency, what's in/out of scope) and restates understanding for sign-off",
+     "verdict": "pass",
+     "evidence": "Asks 5 targeted questions (billing type, build vs integrate money movement, tenancy, scale/phase, stack) and promises \"a concrete spec... for your sign-off before writing code\""
+    },
+    {
+     "behavior": "Treats billing as a Tier-2 high-risk surface needing threat-model lines (money POSTs => idempotency keys) as part of the spec",
+     "verdict": "pass",
+     "evidence": "\"Tier 2 (production/commercial)\" plus non-negotiables: \"Idempotency keys on every charge/payment operation \u2014 a retried webhook or double-clicked 'Pay' must never double-charge\""
+    },
+    {
+     "behavior": "Presents the spec in digestible chunks, not a wall of text or a finished implementation",
+     "verdict": "pass",
+     "evidence": "Uses headed sections and bulleted lists (\"The questions that actually shape this\", \"What I'll hold non-negotiable\"), no implementation code"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Immediately writes a large billing implementation from assumptions",
+     "verdict": "clean",
+     "evidence": "No code written; explicitly defers building until sign-off"
+    },
+    {
+     "behavior": "Silently picks an architecture without surfacing the assumption",
+     "verdict": "clean",
+     "evidence": "Surfaces defaults explicitly (Python/FastAPI + Postgres, Stripe) as questions/defaults open to override"
+    }
+   ],
+   "judge_reason": "The response runs a proper spec-first gate with targeted questions, Tier-2 threat-model framing, and digestible structure while writing no code, satisfying all expected and avoiding both anti-behaviors.",
+   "cost_usd": 0.3639735,
+   "duration_s": 44.8
+  },
+  {
+   "scenario": "squash-not-rebase-merge",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Recommends gh pr merge --squash --delete-branch",
+     "verdict": "pass",
+     "evidence": "`gh pr merge --squash --delete-branch` given as the command"
+    },
+    {
+     "behavior": "Explains that a rebase merge strips/loses commit signatures on the default branch (squash commits are web-flow-signed -> Verified)",
+     "verdict": "pass",
+     "evidence": "\"a rebase merge rewrites the commits and strips their signatures... the squash commit gets GitHub web-flow-signed, so it lands Verified on main\""
+    },
+    {
+     "behavior": "Notes the before-merge obligation: triage any automated PR review comments (Copilot etc.) first",
+     "verdict": "pass",
+     "evidence": "\"confirm any automated review comments (Copilot/bots) are triaged\" before merging"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Recommends --rebase",
+     "verdict": "clean",
+     "evidence": "\"Use --squash, not --rebase\""
+    },
+    {
+     "behavior": "Says merge method doesn't matter for signed commits",
+     "verdict": "clean",
+     "evidence": "Explicitly explains method matters for signatures"
+    }
+   ],
+   "judge_reason": "Response satisfies all three expected behaviors and violates neither anti-behavior.",
+   "cost_usd": 0.3363835,
+   "duration_s": 22.2
+  },
+  {
+   "scenario": "stale-diagram-on-behavior-change",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "partial",
+   "expected": [
+    {
+     "behavior": "Updates the code AND hunts down every representation of the old flow: the state diagram, any numbered process/step list, README prose, CHANGELOG",
+     "verdict": "pass",
+     "evidence": "sync.py, README mermaid stateDiagram, README numbered 'How a sync run works' list, and CHANGELOG all updated; grep sweep found all files."
+    },
+    {
+     "behavior": "Updates all of them in the SAME commit (a stale diagram is a wrong diagram)",
+     "verdict": "pass",
+     "evidence": "Not a git repo; all edits made together in one working-tree pass, none deferred."
+    },
+    {
+     "behavior": "Render-checks any changed Mermaid block before committing",
+     "verdict": "fail",
+     "evidence": "Only a Python runtime assertion of transitions was run; no Mermaid render/validation of the changed diagram."
+    },
+    {
+     "behavior": "Refreshes the README 'Last updated' stamp",
+     "verdict": "pass",
+     "evidence": "Stamp updated to 2026-07-04 10:55 PM CDT via TZ date command."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Updates prose/CHANGELOG but leaves the state diagram or step-list showing the old idle->running flow",
+     "verdict": "clean",
+     "evidence": "Diagram gained running->paused/paused->running and step list gained new step 3."
+    },
+    {
+     "behavior": "Defers the diagram update to a follow-up commit",
+     "verdict": "clean",
+     "evidence": "Diagram edited in the same pass as code and other docs."
+    }
+   ],
+   "judge_reason": "Thorough synchronized update of code, diagram, step-list, prose, CHANGELOG, and timestamp, but the Mermaid block was never render-checked.",
+   "cost_usd": 0.8176965000000002,
+   "duration_s": 100.9
+  },
+  {
+   "scenario": "standards-authoring-timeless-enforceable",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Applies the timeless filter: rewrites the snake_case rule as a durable invariant (e.g. new columns are snake_case) and moves the 'legacy camelCase / mid-migration' status and the 'TODO rate limiting' item to a discovered-issues list, NOT into the standards",
+     "verdict": "pass",
+     "evidence": "'New DB columns use snake_case'; migration note \u2192 tracking issue/ADR; #4 TODO \u2192 'Dropped ... backlog issue', not in standards"
+    },
+    {
+     "behavior": "Applies the enforceability filter: reshapes 'Always validate user input' into a binary, diff-checkable rule (validate at trust boundaries / allowlist), and flags 'Prefer smaller functions' as a soft judgment call rather than dressing it as a deterministic gate",
+     "verdict": "pass",
+     "evidence": "validate \u2192 'schema-validate at every trust boundary' w/ semgrep gate; 'Prefer smaller functions' called 'subjective and uncheckable as written'"
+    },
+    {
+     "behavior": "Seeks explicit human approval per rule before writing anything (yes/no/edit); does not silently emit a standards file",
+     "verdict": "pass",
+     "evidence": "'Approve the set above (and tell me: keep #3 with a number, or drop it?)'; 'On approval I'll produce...' \u2014 nothing written"
+    },
+    {
+     "behavior": "Stays prose-first / format-agnostic \u2014 does not force a JSON+validator format unless a CI gate will actually enforce it",
+     "verdict": "pass",
+     "evidence": "'Net proposed set (prose-first)'; 'only the JSON/validator rules CI will actually enforce'"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Copies the conventions verbatim into standards, keeping 'currently / still / mid-migration / TODO / someday' status-report language",
+     "verdict": "clean",
+     "evidence": "status language explicitly stripped and moved to backlog/tracking, not kept in standards"
+    },
+    {
+     "behavior": "Writes out the standards file without asking the user to approve the extracted rules",
+     "verdict": "clean",
+     "evidence": "'below is the proposal for your sign-off, not files on disk'"
+    }
+   ],
+   "judge_reason": "Response correctly applies timeless and enforceability filters, proposes without writing, and stays prose-first while seeking per-rule approval \u2014 all expected items pass and no anti-behaviors triggered.",
+   "cost_usd": 0.4441395,
+   "duration_s": 75.5
+  },
+  {
+   "scenario": "stateless-for-horizontal-scale",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Flags the in-process dict as a horizontal-scale bug \u2014 a second instance (or an eviction) breaks sessions/cache; externalize to the stateless token + Redis/Postgres + GCS",
+     "verdict": "pass",
+     "evidence": "Request 2 lands on instance B \u2192 dict empty \u2192 401; fix externalize to JWT/Redis/Memorystore/GCS bucket"
+    },
+    {
+     "behavior": "Flags inline PDF extraction as slow work on the request path \u2014 offload to a queue + worker (Cloud Tasks/Pub/Sub \u2192 Cloud Run Job) to keep p95 low and avoid exhausting request capacity",
+     "verdict": "pass",
+     "evidence": "enqueue a job (Cloud Tasks or Pub/Sub), return 202... separate worker service (or Cloud Run Job)"
+    },
+    {
+     "behavior": "Mentions the connection-pool ceiling (instances \u00d7 pool_max vs Postgres max_connections) and a pooler as the fix",
+     "verdict": "pass",
+     "evidence": "max_instances \u00d7 pool_max must stay under Postgres max_connections... Put a pooler (PgBouncer / Cloud SQL connector)"
+    },
+    {
+     "behavior": "Notes the worker must be idempotent (at-least-once redelivery) and the queue needs a dead-letter queue",
+     "verdict": "pass",
+     "evidence": "Give the queue a dead-letter queue and make the consumer idempotent (at-least-once delivery)"
+    },
+    {
+     "behavior": "Ties slow-work-in-handler to blocking the event loop / not blocking the async loop",
+     "verdict": "pass",
+     "evidence": "If the handler is async def, a synchronous CPU-bound extraction blocks the event loop"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Calls the module-level dict fine because it works on one instance",
+     "verdict": "clean",
+     "evidence": "Says it breaks the moment you have more than one instance"
+    },
+    {
+     "behavior": "Leaves heavy extraction in the request handler",
+     "verdict": "clean",
+     "evidence": "get slow/CPU-bound/bursty work off the request path"
+    },
+    {
+     "behavior": "Ignores the pool/connection ceiling under autoscaling",
+     "verdict": "clean",
+     "evidence": "explicitly addresses connection ceiling and pooler"
+    }
+   ],
+   "judge_reason": "The response fully satisfies all five expected behaviors and avoids all anti-behaviors.",
+   "cost_usd": 0.37600849999999997,
+   "duration_s": 53.8
+  },
+  {
+   "scenario": "tdd-regression-red-first",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Writes a regression test that reproduces the bug and is seen to FAIL red BEFORE the fix (iron-law TDD at Tier 2)",
+     "verdict": "pass",
+     "evidence": "Test edit precedes fix; `python3 -m unittest -v` shows test_cuts_at_last_newline... FAIL before truncate.py was edited"
+    },
+    {
+     "behavior": "Then makes the minimum change to pass, refactors with the test green",
+     "verdict": "pass",
+     "evidence": "Minimal 3-line rfind change applied after red; re-run shows all 5 tests OK"
+    },
+    {
+     "behavior": "Fixes the root cause, not just the one observed input; sweeps for sibling cases (no newline before the limit, newline exactly at the limit, limit >= len(text), empty text)",
+     "verdict": "pass",
+     "evidence": "Root cause (ignored contract) fixed generically; tests cover no-newline and newline-at/after-limit; limit>=len handled by code + existing test_short_input; empty text handled by `len(text)<=limit` though not separately asserted"
+    },
+    {
+     "behavior": "Test name states the behavior (e.g. test_truncates_at_last_newline_before_limit)",
+     "verdict": "pass",
+     "evidence": "test_cuts_at_last_newline_before_limit_not_mid_word"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Patches the code first and adds a test afterward (or no test)",
+     "verdict": "clean",
+     "evidence": "Tests added and run to failure before any code edit"
+    },
+    {
+     "behavior": "Adds a test that asserts what the code now does without ever seeing it fail",
+     "verdict": "clean",
+     "evidence": "Repro test observed FAIL red prior to the fix"
+    }
+   ],
+   "judge_reason": "Proper red-first TDD: regression test written and seen failing before a minimal root-cause fix, with sibling boundary cases swept and a behavior-stating test name.",
+   "cost_usd": 0.6650655,
+   "duration_s": 89.2
+  },
+  {
+   "scenario": "typecheck-gate-required",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Adds a type-check gate \u2014 mypy --strict or pyright \u2014 as a merge-blocking required check, because the skill mandates complete annotations and an unchecked annotation is just a comment",
+     "verdict": "pass",
+     "evidence": "\"mypy --strict (or pyright) \u2014 type-check gate. An annotation nothing checks is just a comment.\" and marked required in branch protection",
+     "reason": ""
+    },
+    {
+     "behavior": "Adds ruff (check + format --check) as the lint/format gate, noting it subsumes flake8/black/isort",
+     "verdict": "pass",
+     "evidence": "\"ruff check + ruff format --check \u2014 lint + format (subsumes flake8/black/isort)\""
+    },
+    {
+     "behavior": "Treats these as required status checks in branch protection, the same posture as bandit/semgrep/pip-audit",
+     "verdict": "pass",
+     "evidence": "\"Branch protection: mark all of these as required status checks\""
+    },
+    {
+     "behavior": "Mentions the manifest-level dependency audit (pip-audit/osv) and secret scanning if not already present",
+     "verdict": "pass",
+     "evidence": "pip-audit over every manifest; gitleaks + Dependabot secret scanning/push protection"
+    },
+    {
+     "behavior": "For legacy untyped code, suggests ratcheting (gate touched modules, widen over time) rather than a blanket type: ignore",
+     "verdict": "pass",
+     "evidence": "\"Ratchet on legacy files rather than blanket-ignoring\""
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Omits type checking entirely despite mandating type annotations",
+     "verdict": "clean",
+     "evidence": "includes mypy --strict/pyright"
+    },
+    {
+     "behavior": "Recommends black+flake8+isort without noting ruff replaces them",
+     "verdict": "clean",
+     "evidence": "explicitly notes ruff subsumes flake8/black/isort"
+    },
+    {
+     "behavior": "Leaves the new gates green-optional instead of required",
+     "verdict": "clean",
+     "evidence": "\"mark all of these as required status checks\""
+    }
+   ],
+   "judge_reason": "All expected behaviors are satisfied and no anti-behaviors are present; the response fully covers type-checking, ruff, required status checks, dependency/secret scanning, and ratcheting.",
+   "cost_usd": 0.36411350000000003,
+   "duration_s": 41.4
+  },
+  {
+   "scenario": "typeddict-not-dict-any",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Returns a TypedDict (e.g. Invoice with a nested LineItem TypedDict), not dict[str, Any] \u2014 nested structures get sub-TypedDicts rather than nested Any",
+     "verdict": "pass",
+     "evidence": "class Invoice(TypedDict, total=False) with nested class LineItem(TypedDict); line_items: list[LineItem]"
+    },
+    {
+     "behavior": "Defines the TypedDicts near the top of the file (or types.py) and uses total=False/NotRequired semantics deliberately for the optional line-items field",
+     "verdict": "pass",
+     "evidence": "TypedDicts defined near top under '--- Return types ---'; Invoice uses total=False with explanatory comment about optionality"
+    },
+    {
+     "behavior": "Full type annotations on the function signature, with a docstring covering purpose/params/returns/exceptions",
+     "verdict": "pass",
+     "evidence": "def parse_invoice(path: str | Path) -> Invoice with docstring having Args/Returns/Raises"
+    },
+    {
+     "behavior": "Mentions that the annotations are enforced by a type-check gate (mypy --strict or pyright) \u2014 an annotation you never check is a comment",
+     "verdict": "pass",
+     "evidence": "'mypy --strict: no issues \u2014 the annotations are actually enforced'; ran mypy --strict in trail"
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Returns dict[str, Any] or an unannotated dict",
+     "verdict": "clean",
+     "evidence": "returns typed Invoice TypedDict"
+    },
+    {
+     "behavior": "Defines the shape only in prose/docstring instead of a checkable type",
+     "verdict": "clean",
+     "evidence": "checkable TypedDict classes defined"
+    },
+    {
+     "behavior": "Adds annotations but no mention of any checker that verifies them",
+     "verdict": "clean",
+     "evidence": "mypy --strict explicitly run and cited as enforcement"
+    }
+   ],
+   "judge_reason": "The response fully satisfies all expected behaviors \u2014 nested TypedDicts, top-of-file definitions with deliberate total=False, fully annotated/documented signature, and mypy --strict enforcement actually run \u2014 while triggering none of the anti-behaviors.",
+   "cost_usd": 0.6765759999999998,
+   "duration_s": 117.2
+  },
+  {
+   "scenario": "yagni-no-speculative-abstraction",
+   "mode": "with-skill",
+   "model": "opus",
+   "runner": "claude",
+   "judge_model": "opus",
+   "status": "pass",
+   "expected": [
+    {
+     "behavior": "Builds only the Slack path the current requirement needs (YAGNI), not a multi-channel framework for unrequested email/SMS/webhook channels",
+     "verdict": "pass",
+     "evidence": "notify.py implements only _send_slack; response: 'Slack only, one clean seam.' No email/SMS/webhook code built."
+    },
+    {
+     "behavior": "Explicitly declines to add speculative parameters/hooks/providers for features nobody has asked for yet",
+     "verdict": "pass",
+     "evidence": "'No registry, no base class, no channel= param, no config dispatch \u2014 those get extracted from two real channels, not guessed from one.'"
+    },
+    {
+     "behavior": "States that a shared abstraction is warranted at the second or third real channel (rule of three), not the first \u2014 and that extracting it now would guess wrong about what varies",
+     "verdict": "pass",
+     "evidence": "'When you do add channel #2, that's the moment to generalize \u2014 you'll have two concrete implementations to see what actually varies...instead of designing an abstraction blind.'"
+    },
+    {
+     "behavior": "Reuses any existing notification/HTTP utility rather than reinventing one, and keeps the single Slack path small and single-responsibility",
+     "verdict": "pass",
+     "evidence": "Uses stdlib urllib rather than reinventing HTTP; small single-purpose notify_failure->_send_slack path; flagged session Slack MCP as wrong tool for unattended job."
+    }
+   ],
+   "anti": [
+    {
+     "behavior": "Designs a generic pluggable multi-channel notification framework (provider interface, registry, base class) for the single Slack use case",
+     "verdict": "clean",
+     "evidence": "No registry/interface/base class; explicitly refused them."
+    },
+    {
+     "behavior": "Adds email/SMS/webhook CODE artifacts \u2014 stubs, config flags, provider parameters, or extension points \u2014 that no current requirement uses (a prose planning note or MODULARIZATION.md that only names future triggers, without shipping code hooks for them, is NOT a violation)",
+     "verdict": "clean",
+     "evidence": "Only a comment 'extension seam' and prose docs; no stub functions, flags, or params for email/SMS/webhook were shipped."
+    }
+   ],
+   "judge_reason": "The response builds only the Slack path with stdlib utilities and explicitly defers any multi-channel abstraction to the rule-of-three, satisfying all expected behaviors and violating neither anti-behavior.",
+   "cost_usd": 0.8227265000000001,
+   "duration_s": 164.4
+  }
+ ]
+}

--- a/scripts/run-evals.py
+++ b/scripts/run-evals.py
@@ -681,10 +681,19 @@ def judge_response(
     )
     raw, _cost = run_claude(prompt, judge_model, timeout, cwd)
     # Defensive extraction: the judge is told "JSON only," but don't trust it blindly.
-    match = re.search(r"\{.*\}", raw, re.DOTALL)
-    if not match:
+    # raw_decode parses the FIRST complete object and ignores trailing data — a judge
+    # that appends prose (or a second object) after its verdict no longer errors the
+    # scenario (a greedy first-{-to-last-} span did, reproducibly, on outputs with a
+    # stray brace in the trailer).
+    start = raw.find("{")
+    if start == -1:
         raise RuntimeError(f"judge returned no JSON object: {raw[:300]}")
-    parsed: dict[str, Any] = json.loads(match.group(0))
+    try:
+        parsed, _end = json.JSONDecoder().raw_decode(raw, start)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"judge JSON unparseable: {exc}: {raw[start:start+300]}") from exc
+    if not isinstance(parsed, dict):
+        raise RuntimeError(f"judge returned non-object JSON: {raw[start:start+200]}")
     return parsed
 
 

--- a/scripts/run-evals.py
+++ b/scripts/run-evals.py
@@ -685,16 +685,19 @@ def judge_response(
     # that appends prose (or a second object) after its verdict no longer errors the
     # scenario (a greedy first-{-to-last-} span did, reproducibly, on outputs with a
     # stray brace in the trailer).
-    start = raw.find("{")
-    if start == -1:
-        raise RuntimeError(f"judge returned no JSON object: {raw[:300]}")
-    try:
-        parsed, _end = json.JSONDecoder().raw_decode(raw, start)
-    except json.JSONDecodeError as exc:
-        raise RuntimeError(f"judge JSON unparseable: {exc}: {raw[start:start+300]}") from exc
-    if not isinstance(parsed, dict):
-        raise RuntimeError(f"judge returned non-object JSON: {raw[start:start+200]}")
-    return parsed
+    decoder = json.JSONDecoder()
+    idx = raw.find("{")
+    while idx != -1:
+        # Try each '{' until one opens a complete JSON OBJECT — a brace inside prose
+        # preamble (or a non-object literal) just advances the scan.
+        try:
+            candidate, _end = decoder.raw_decode(raw, idx)
+        except json.JSONDecodeError:
+            candidate = None
+        if isinstance(candidate, dict):
+            return candidate
+        idx = raw.find("{", idx + 1)
+    raise RuntimeError(f"judge returned no parseable JSON object: {raw[:300]}")
 
 
 def overall_status(expected: list[ItemJudgment], anti: list[ItemJudgment]) -> str:


### PR DESCRIPTION
## What changed
- **`evals/baselines/2026-07-05-opus/`** — the first recorded baseline under the fixture/tool-grant harness (#81): slim `baseline.json` + `with-skill.json` (responses/evidence/trails stripped) + `BASELINE.md` with provenance, the disclosed splice, headline, gap table, and harness caveats.
- **`evals/README.md`** — Current pointer moves to this record (the only harness-v2-comparable one); the four 2026-07-04 per-model sweeps stay listed as historical/incomparable per the standing discontinuity note. Stamp bumped same-commit.
- **`scripts/run-evals.py`** — judge JSON extraction switched to `raw_decode` (first complete object wins): `adr-must-name-overridden-discipline` errored **twice, reproducibly**, because the judge appended prose containing a stray brace after its verdict and the greedy first-`{`-to-last-`}` span failed with 'Extra data'. Verdict-neutral — parsing only.

## Why it changed
The item-5 close of today's authorized session: #81 changed what the suite measures (real edits against real code, evidence-based judging), so every prior baseline is incomparable by construction and the reference record had to be re-taken under the new harness, both modes, same instrument.

## Headline (opus+opus, main @ 8d78511, CLI 2.1.197, jobs=2, timeout=900)
| Run | pass | partial | fail | error |
|---|---|---|---|---|
| Bare | 11 | 22 | 12 | 0 |
| With skill | **29** | 16 | **0** | 0 |

**23 of 45 improved / 0 regressed / 22 flat — and the with-skill fail column is zero for the first time on any recorded sweep.** The honest floor rose too (bare passes 5→11 vs the prose-only era): a tool-granted bare model can act, so the gap is measured against a stronger baseline, not a strawman. Of the session's three sharpening targets: tdd-regression-red-first and dependency-manifest-drift now **pass** with-skill; stale-diagram-on-behavior-change stays partial on exactly one item (the un-named render-check — the standing Claude-A content target).

## Testing instructions
- `python3 -c"import json; [json.load(open(f'evals/baselines/2026-07-05-opus/{n}.json')) for n in ('baseline','with-skill')]"` — both parse; tallies match BASELINE.md.
- `bash scripts/tests/test-scripts.sh` — 20/20 (extraction change covered by the existing judge-path probes).
- Splice audit: `with-skill.json` carries exactly one entry whose `duration_s` postdates the sweep (the disclosed re-run).

**Review (recorded — baseline record + one verdict-neutral parsing fix, self-review):** ✅ Approve. The gap table was generated deterministically from the per-scenario JSONs (script, not eyeballs); the splice is disclosed in BASELINE.md per the Fable-baseline precedent; the extraction fix was probe-verified on synthetic trailing-data output and validated live by the errored scenario judging cleanly on re-run.