### PR TITLE
docs(policy): citation-validate is now a required check

### DIFF
--- a/.github/workflows/citation-validate.yml
+++ b/.github/workflows/citation-validate.yml
@@ -8,8 +8,8 @@ name: citation-validate
 # (x-release-please annotations in CITATION.cff): a bump that breaks the schema fails here,
 # not on a reader's citation.
 #
-# GREEN-OPTIONAL by design: not in the ruleset's required checks — promotion to required is
-# the maintainer's explicit call, never a default.
+# REQUIRED status check since 2026-07-05 (promoted from green-optional on the maintainer's
+# explicit call — promotion to required is never a default).
 
 on:
   push:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,7 +101,7 @@ may not be checkable enough yet.
   every review thread addressed or resolved. We don't merge on green CI alone: green proves the
   *gates* passed, not that the change is correct, in-scope, and free of a subtle regression a check
   didn't cover.
-- The repo's **required checks** (`docs-render`, `leakage-guard`, `shellcheck`, `skill-lint`, `script-tests`) must pass.
+- The repo's **required checks** (`docs-render`, `leakage-guard`, `shellcheck`, `skill-lint`, `script-tests`, `citation-validate`) must pass.
 - Merges are **squash-only** — rebase-merge (it rewrites your commits *unsigned*) and merge-commit
   are both disabled — and the branch is auto-deleted on merge. GitHub signs the squash commit, so
   your contribution lands **Verified** on `main` even if your own commits weren't signed; you don't

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,7 @@ This project is maintained by:
 ## How we work
 
 - Every change lands via a pull request with the required checks green (`docs-render`, `leakage-guard`,
-  `shellcheck`, `skill-lint`, `script-tests`) and a maintainer review — see [CONTRIBUTING.md](CONTRIBUTING.md).
+  `shellcheck`, `skill-lint`, `script-tests`, `citation-validate`) and a maintainer review — see [CONTRIBUTING.md](CONTRIBUTING.md).
 - The branch ruleset requires **1 approving review**. The maintainer (repo admin) can self-merge
   their *own* PRs via an admin bypass, so a solo merge is never blocked — while every *other*
   contributor's PR gets a genuine four-eyes review before it lands.
@@ -48,7 +48,7 @@ bumps the `Version` in [`SKILL.md`](SKILL.md) (and `version`/`date-released` in
 1. **Enrich the changelog.** In the open release PR, edit the new `CHANGELOG.md` section to add the
    curated "what + **why**" narrative (the prose this skill values), then mark the PR ready.
 2. **Merge the release PR.** Because release-please authored it with `GITHUB_TOKEN`, the
-   `leakage-guard` / `docs-render` / `shellcheck` / `skill-lint` / `script-tests` checks don't auto-run on it; review the (generated) diff and
+   `leakage-guard` / `docs-render` / `shellcheck` / `skill-lint` / `script-tests` / `citation-validate` checks don't auto-run on it; review the (generated) diff and
    admin-merge: `gh pr merge --squash --admin`.
 3. **Cut the signed tag + GitHub Release** from the merged `main`:
    ```bash

--- a/README.md
+++ b/README.md
@@ -348,8 +348,8 @@ stale-claim discipline as the badge row:
   `x-release-please-version` / `x-release-please-date` annotations in the file mark the
   lines it rewrites in each release PR (the same mechanism as `SKILL.md`'s version stamp).
 - **The file is schema-validated as a gate**: `scripts/validate-citation.sh` (digest-pinned
-  `cffconvert` container) runs verbatim locally and as the green-optional
-  `citation-validate` CI check.
+  `cffconvert` container) runs verbatim locally and as the **required** `citation-validate`
+  CI check — an invalid citation file cannot merge.
 
 ## License
 


### PR DESCRIPTION
## What changed
The six-check enumeration lands everywhere it's stated: `MAINTAINERS.md` (How-we-work + the release-PR suppression note), `CONTRIBUTING.md`, the README's citation section (green-optional → **required**, with the consequence stated: an invalid citation file cannot merge), and `citation-validate.yml`'s own header comment.

## Why it changed
Ruleset 18154173 was updated today on the maintainer's explicit authorization — `citation-validate` joins the required set (now 6). Docs enumerating the set move in the same pass, workflow headers included (the #77 stale-header lesson).

## Testing instructions
- `gh api repos/bjgreenberg/senior-engineering-partner/rulesets/18154173 --jq '.rules[] | select(.type=="required_status_checks")'` matches every enumeration in this diff.
- `git grep -in 'green-optional' -- '*.md' .github/` — remaining hits are generic discipline prose in references + CHANGELOG history, not claims about this repo's live set.

**Review (recorded — docs-only enumeration diff, self-review):** ✅ Approve. This PR merges under the new 6-check gate including `citation-validate` itself (dogfood proof).