### PR TITLE
feat(plugin): package the skill as a Claude Code plugin with a self-hosted marketplace

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,29 @@
+{
+  "name": "bjgreenberg",
+  "owner": {
+    "name": "Brian Greenberg"
+  },
+  "description": "Claude Code plugins by Brian Greenberg",
+  "plugins": [
+    {
+      "name": "senior-engineering-partner",
+      "source": "./",
+      "description": "A strict code reviewer, pair programmer, debugger, and mentor for Python, Bash, Google Apps Script, and JavaScript — a security-first, phase-aware engineering discipline with an enforced spec → plan → TDD → verify workflow.",
+      "category": "engineering",
+      "keywords": [
+        "code-review",
+        "security",
+        "tdd",
+        "debugging",
+        "python",
+        "bash"
+      ],
+      "author": {
+        "name": "Brian Greenberg"
+      },
+      "homepage": "https://github.com/bjgreenberg/senior-engineering-partner",
+      "repository": "https://github.com/bjgreenberg/senior-engineering-partner",
+      "license": "Apache-2.0"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
+  "name": "senior-engineering-partner",
+  "displayName": "Senior Engineering Partner",
+  "description": "A strict code reviewer, pair programmer, debugger, and mentor for Python, Bash, Google Apps Script, and JavaScript — a security-first, phase-aware engineering discipline with an enforced spec → plan → TDD → verify workflow.",
+  "version": "1.16.2",
+  "author": {
+    "name": "Brian Greenberg",
+    "url": "https://briangreenberg.net"
+  },
+  "homepage": "https://github.com/bjgreenberg/senior-engineering-partner",
+  "repository": "https://github.com/bjgreenberg/senior-engineering-partner",
+  "license": "Apache-2.0",
+  "keywords": [
+    "code-review",
+    "security",
+    "tdd",
+    "debugging",
+    "engineering-discipline",
+    "python",
+    "bash",
+    "apps-script",
+    "javascript"
+  ],
+  "skills": ["./"]
+}

--- a/.github/workflows/plugin-validate.yml
+++ b/.github/workflows/plugin-validate.yml
@@ -1,0 +1,33 @@
+name: plugin-validate
+
+# Validate the Claude Code plugin + marketplace manifests (.claude-plugin/plugin.json and
+# .claude-plugin/marketplace.json) with the official validator. A manifest that fails to parse
+# breaks `/plugin marketplace add` for every user — a broken deliverable, like a failing test —
+# so the manifests are gated the same way the Mermaid diagrams (docs-render) and CITATION.cff
+# (citation-validate) are. `--strict` promotes validator warnings (e.g. a misspelled manifest
+# field) to failures.
+#
+# Supply chain: the CLI is version-pinned and fetched via npx from the npm registry, which
+# integrity-checks the tarball against its registry metadata. This is a version pin, not a
+# committed hash-lock (no lockfile in this repo for a CI-only tool); the validator runs no
+# repo-controlled code beyond parsing JSON/frontmatter. Bump the pin deliberately (SKILL.md
+# "stay current, not just pinned").
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  plugin-validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+      - name: Validate plugin + marketplace manifests
+        run: |
+          set -euo pipefail
+          npx --yes @anthropic-ai/claude-code@2.1.197 plugin validate . --strict

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,9 +61,10 @@ regular collaborators use a branch on the repo. Either way:
 7. **If you encode a discipline, guard it with an eval.** New or changed rules should add or extend
    a scenario in `evals/` — the project's "changelog is the spec, evals are the tests" model.
 8. **Run the gates locally** before opening the PR: `bash scripts/leakage-guard.sh`,
-   `bash scripts/render-diagrams.sh` (render-check any Mermaid you touched), and — if you touched a
-   helper script — `shellcheck scripts/*.sh`. Locally-green is necessary but **not sufficient** —
-   the PR's required checks are the source of truth.
+   `bash scripts/render-diagrams.sh` (render-check any Mermaid you touched), if you touched a
+   helper script — `shellcheck scripts/*.sh`, and if you touched the plugin/marketplace manifests
+   under `.claude-plugin/` — `claude plugin validate . --strict`. Locally-green is necessary but
+   **not sufficient** — the PR's required checks are the source of truth.
 9. **Open the PR** with the **What changed / Why it changed / Testing** description (the PR template
    gives you the shape). Open it as a **draft** while it's WIP so CI runs but it can't merge early;
    mark it ready when it is. Link the issue it closes (`Closes #N`).

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -29,8 +29,11 @@ This project is maintained by:
 Releases are **prepared by [release-please](https://github.com/googleapis/release-please) and
 finished by a maintainer.** release-please watches `main`, derives the next version from the
 [Conventional Commits](https://www.conventionalcommits.org/), and keeps an open *release PR* that
-bumps the `Version` in [`SKILL.md`](SKILL.md) (and `version`/`date-released` in
-[`CITATION.cff`](CITATION.cff)) and prepends the new section to
+bumps the `Version` in [`SKILL.md`](SKILL.md) (plus `version`/`date-released` in
+[`CITATION.cff`](CITATION.cff) and `version` in
+[`.claude-plugin/plugin.json`](.claude-plugin/plugin.json) — the latter via a JSONPath
+updater, so the plugin-marketplace install channel offers the update the moment the release
+lands) and prepends the new section to
 [`CHANGELOG.md`](CHANGELOG.md). It deliberately stops there (`skip-github-release: true`): the
 `tag-protection` ruleset requires **signed** tags, and a bot tagging via the API produces an
 *unsigned* tag the ruleset would reject — so a maintainer cuts the signed tag and Release by hand.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # senior-engineering-partner
 
-Last updated: 2026-07-04 04:47 PM CDT
+Last updated: 2026-07-07 09:54 PM CDT
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/bjgreenberg/senior-engineering-partner?sort=semver&label=release)](https://github.com/bjgreenberg/senior-engineering-partner/releases)
@@ -229,7 +229,33 @@ support directories:
 
 ## Install
 
-Claude Code loads skills from `~/.claude/skills/`. Install by cloning this repo into that
+Two ways into Claude Code — pick **one** (a side-by-side plugin install and skill clone
+would load the skill twice):
+
+### As a plugin (quickest)
+
+The repo doubles as its own single-plugin marketplace
+([`.claude-plugin/marketplace.json`](.claude-plugin/marketplace.json)), so two commands
+inside Claude Code install it:
+
+```
+/plugin marketplace add bjgreenberg/senior-engineering-partner
+/plugin install senior-engineering-partner@bjgreenberg
+```
+
+Updates track the versioned
+[Releases](https://github.com/bjgreenberg/senior-engineering-partner/releases): refresh
+with `/plugin marketplace update bjgreenberg` and Claude Code offers the new version.
+**Trade-off:** plugin installs are copied into Claude Code's plugin cache and replaced
+wholesale on every update, so the per-user environment profile
+(`references/my-environment.md`, [next section](#customize-for-your-environment-my-environmentmd))
+cannot persist there — a plugin install always runs the universal core against the assumed
+baseline (macOS, Bash, GitHub, a secret manager, a scale-to-zero cloud target). That is the
+right default for most users; to customize the profile, use the clone install instead.
+
+### As a skill clone (customizable)
+
+Claude Code also loads skills from `~/.claude/skills/`. Clone this repo into that
 directory under the skill's own name:
 
 ```bash
@@ -237,11 +263,12 @@ git clone https://github.com/bjgreenberg/senior-engineering-partner \
   ~/.claude/skills/senior-engineering-partner
 ```
 
-Then **customize it for your environment** (next section) and invoke it with
-`/senior-engineering-partner` (optionally prefixed with a mode trigger word). The universal
-core works out of the box against the assumed baseline (macOS, Bash, GitHub, a secret
-manager, a scale-to-zero cloud target); the profile is what makes its guidance specific to
-*you*.
+Then **customize it for your environment** (next section); update with a plain `git pull`
+in the clone.
+
+Either way, invoke it with `/senior-engineering-partner` (optionally prefixed with a mode
+trigger word). The universal core works out of the box against the assumed baseline; the
+profile is what makes its guidance specific to *you*.
 
 ## Using it with other AI tools (Codex, Gemini CLI, …)
 

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -9,7 +9,12 @@
       "skip-github-release": true,
       "extra-files": [
         "SKILL.md",
-        "CITATION.cff"
+        "CITATION.cff",
+        {
+          "type": "json",
+          "path": ".claude-plugin/plugin.json",
+          "jsonpath": "$.version"
+        }
       ]
     }
   }


### PR DESCRIPTION
## What changed
- **`.claude-plugin/plugin.json`** — single-skill plugin manifest: the root `SKILL.md` is the skill (explicit `"skills": ["./"]`, the documented plugin-root form); `version` pinned at `1.16.2` so plugin updates track Releases, not every commit.
- **`.claude-plugin/marketplace.json`** — the repo doubles as its own single-plugin marketplace `bjgreenberg` with one entry, `source: "./"`. No `version` in the entry (the docs warn `plugin.json` silently wins when both are set).
- **`release-please-config.json`** — a JSONPath-typed `extra-files` entry bumps `plugin.json`'s `version` on every release (syntax verified against the release-please docs).
- **`.github/workflows/plugin-validate.yml`** — new gate: `claude plugin validate . --strict` via a version-pinned `npx` (2.1.197). Ships green-optional; promotion to a required check is the repo owner's call, per house pattern.
- **Docs, same commit** — README Install section now offers both paths (plugin = quickest, clone = customizable) and names the trade-off: the plugin cache is replaced on update, so `references/my-environment.md` customization requires the clone install. CONTRIBUTING local-gates list and the MAINTAINERS release runbook updated. CHANGELOG deliberately untouched (release-please owns it).

## Why it changed
Requested in [discussion #86](https://github.com/bjgreenberg/senior-engineering-partner/discussions/86): a two-command install instead of a manual clone. Verified against the official plugin/marketplace docs that a plugin with `SKILL.md` at its root is a first-class single-skill plugin — so this ships with **zero restructuring** of the existing layout, and the clone path (Claude Code, Codex CLI, Gemini CLI) is unchanged.

```
/plugin marketplace add bjgreenberg/senior-engineering-partner
/plugin install senior-engineering-partner@bjgreenberg
```

## Testing
- `claude plugin validate . --strict` → **passed** (marketplace + plugin manifests).
- Full local end-to-end from a clean worktree (no gitignored private files present): `claude plugin marketplace add <worktree>` → `claude plugin install senior-engineering-partner@bjgreenberg` → installed at cache path `bjgreenberg/senior-engineering-partner/1.16.2/` with the full tree and **no private files**; `claude plugin details` reports **Skills (1): senior-engineering-partner** (~250 tok always-on, ~19.6k on invoke). Test marketplace/plugin removed after.
- Evidence the validator needs no login: in the same sandbox where headless `claude -p` fails with "Not logged in", `plugin validate` succeeds — so the CI job should run unauthenticated. If it doesn't, the fallback is a jq structural check (documented substitution).
- `bash scripts/leakage-guard.sh` (Tier 2, denylist present) → **PASS**.
- No Mermaid, shell scripts, or SKILL.md touched; those gates run on this PR as the source of truth.

## Review
Structured self-review recorded per house policy (correctness / security / blast-radius): existing installs and forks unaffected (clone flow unchanged); new workflow is optional so it cannot block unrelated PRs; no secrets or private identifiers introduced (Tier-2 guard green); the one deferred risk is the release-please JSONPath updater, which is docs-verified but not yet exercised — the MAINTAINERS runbook now tells the release-PR reviewer to check the `plugin.json` diff. Packaging/infra change, below the high-stakes bar — no adversarial panel (tier-gate). Automated reviewer findings will be triaged before merge.