### PR TITLE
docs(privacy): plugin-specific PRIVACY.md — the plugin collects nothing

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,0 +1,36 @@
+# Privacy Policy — senior-engineering-partner
+
+Last updated: 2026-07-07 10:47 PM CDT
+
+This policy covers the `senior-engineering-partner` plugin: the Agent Skill (`SKILL.md`),
+its reference library (`references/`), its evaluation suite (`evals/`), and its helper
+scripts (`scripts/`), however installed (Claude Code plugin marketplace, git clone, or any
+other Agent-Skills-compatible tool).
+
+## What the plugin collects: nothing
+
+- The plugin is **static Markdown instructions** loaded locally by your AI coding
+  assistant. It contains **no telemetry, no analytics, no usage tracking, no accounts, no
+  cookies**, and it stores no personal data.
+- It bundles **no MCP servers, no hooks, and no background processes** — its component
+  inventory is exactly one skill.
+- The skill itself makes **no network calls**. The optional helper scripts under
+  `scripts/` (dependency audit, Mermaid render-check, citation validation, eval runner)
+  run **only when you invoke them explicitly**, and contact only the standard developer
+  services those tools require (for example, the OSV vulnerability database via
+  `pip-audit`, a container registry for the pinned render image, or your local `claude`
+  CLI). They transmit nothing else and report nothing back to the plugin's author.
+
+## Your conversation and code
+
+Prompts, code, and files you work on while the skill is loaded are processed by the AI
+product you run it in — not by this plugin. That processing is governed by the product
+vendor's own privacy policy (for Claude Code, see
+[Anthropic's privacy policy](https://www.anthropic.com/legal/privacy)).
+
+## Changes and contact
+
+Changes to this policy land as ordinary commits to this file, so its full history is
+auditable in git. Questions or concerns: open a
+[GitHub issue](https://github.com/bjgreenberg/senior-engineering-partner/issues), or use
+the maintainer contact in [`MAINTAINERS.md`](MAINTAINERS.md).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # senior-engineering-partner
 
-Last updated: 2026-07-07 10:10 PM CDT
+Last updated: 2026-07-07 10:47 PM CDT
 
 [![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
 [![Latest release](https://img.shields.io/github/v/release/bjgreenberg/senior-engineering-partner?sort=semver&label=release)](https://github.com/bjgreenberg/senior-engineering-partner/releases)
@@ -422,6 +422,9 @@ stale-claim discipline as the badge row:
 ## License
 
 Apache-2.0 © Brian Greenberg. See [`LICENSE`](LICENSE) and [`NOTICE`](NOTICE).
+
+Privacy: the plugin collects no data — no telemetry, no network calls, no tracking. The
+full statement lives in [`PRIVACY.md`](PRIVACY.md).
 
 <sub>[↑ Back to contents](#contents)</sub>
 


### PR DESCRIPTION
## What changed
- New `PRIVACY.md`: the plugin-scoped privacy statement — static Markdown, zero collection (no telemetry/analytics/accounts/tracking), no MCP servers or hooks; the optional helper scripts contact only the developer services they wrap (OSV via pip-audit, the pinned render image's registry, the local claude CLI) and only when explicitly run; conversation/code data is governed by the host product's policy (Anthropic's linked).
- README License section links it (one sentence, no new heading — the Contents ToC is untouched); `Last updated` stamp bumped same-commit.

## Why it changed
The community-marketplace submission form marks the privacy-policy URL as **'Required for Anthropic Verified Status.'** A plugin-scoped statement is more accurate for that review than the author's site-wide policy, and the honest content is simple: this plugin collects nothing.

## Testing
- Tier-2 leakage-guard → PASS locally; no Mermaid/scripts/manifests touched.
- Claim-accuracy check: 'no network calls' is scoped to the skill itself, with the helper-script exceptions named explicitly (audit.sh/render-diagrams.sh/run-evals.py do reach external services when invoked) — no overclaim.

## Review
Self-review recorded: docs-only, additive; the policy names its own change process (git history); README ToC anchors unaffected (no heading added). Automated reviewer findings will be triaged before merge.