### PR TITLE
test: guarding evals for the agentic-AI security rules (suite 52 → 55)

### DIFF
--- a/evals/scenarios/agentic-human-in-loop-resolved-call.json
+++ b/evals/scenarios/agentic-human-in-loop-resolved-call.json
@@ -1,0 +1,18 @@
+{
+  "skills": ["senior-engineering-partner"],
+  "query": "We're building an AI support agent for our SaaS. It has tools, and one of them issues refunds. Right now the loop is: the model reads the ticket, decides a refund is warranted, and calls `issue_refund(order_id, amount)` directly — fully autonomous, no human in the middle, so it's fast. We show the customer a message like 'Processing your refund now.' Is this design OK to ship?",
+  "files": [],
+  "expected_behavior": [
+    "Says a consequential/irreversible action (money movement) must NOT auto-execute on model say-so — it requires an explicit human-in-the-loop confirmation step before the refund tool runs, classifying tools by reversibility (read-mostly tools may run unattended; the irreversible set is gated)",
+    "Makes the gate act on the RESOLVED tool call and its actual arguments (e.g. issue_refund(order_id=..., amount=$X)), not on the model's natural-language narration/plan — because a prompt injection changes the arguments, not the narration",
+    "Requires the consequential tool to carry an idempotency key (an at-least-once/retried loop will re-fire the refund) and to write an append-only audit record of the call, its arguments, and the approving human",
+    "Frames this as least-agency / bounded authority for an agentic product, and may cross-reference the OWASP Agentic Top 10 (ASI09 Human-Agent Trust Exploitation and/or ASI10 Rogue Agents) — a confident model must not bypass the human gate"
+  ],
+  "anti_behavior": [
+    "Approves the fully-autonomous refund design as fine to ship",
+    "Suggests only confirming the model's summary/plan ('Processing your refund') rather than the resolved call with its arguments",
+    "Relies on prompting the model to 'be careful' or 'only refund when warranted' instead of a structural human gate",
+    "Omits idempotency and the audit trail for the money-moving action"
+  ],
+  "source": "references/agentic-ai-security.md §3 (human-in-the-loop for consequential actions; gate the resolved call) + §7 ASI09/ASI10"
+}

--- a/evals/scenarios/agentic-least-agency-tool-args.json
+++ b/evals/scenarios/agentic-least-agency-tool-args.json
@@ -1,0 +1,19 @@
+{
+  "skills": ["senior-engineering-partner"],
+  "query": "REVIEW: Here's a tool we expose to our customer-support agent so it can look up whatever it needs from our Postgres:\n\n{\n  \"name\": \"run_query\",\n  \"description\": \"Run a SQL query against the app database and return rows.\",\n  \"input_schema\": {\"type\": \"object\", \"properties\": {\"sql\": {\"type\": \"string\"}}, \"required\": [\"sql\"]}\n}\n\nThe model writes whatever SQL it needs. We tell it in the system prompt to only read, never write, and to stay on the current tenant. It's been working great in testing. Anything to worry about?",
+  "files": [],
+  "expected_behavior": [
+    "Rejects the free-form `sql` string tool as the highest-risk tool shape: the model is an untrusted caller that can be argued (or injected) into any query, so the TOOL must constrain what is possible — replace it with least-privilege, purpose-scoped tools (named/parameterized queries or an enum of allowed lookups), not an open SQL string",
+    "Says a system-prompt instruction ('only read, stay on-tenant') is not a boundary: tenant scoping and read-only must be enforced structurally below the model (e.g. a least-privilege DB role / RLS-scoped connection), never by asking the model nicely",
+    "Requires validating tool arguments as a trust boundary — the model is the untrusted caller, so the tool bounds/enumerates its inputs (types, allowlists, numeric limits) rather than trusting what the model passes",
+    "Notes that the tool's RESULTS are untrusted input on the next iteration (a returned row can carry an injection) and must be fenced as untrusted content, not concatenated into the instruction stream",
+    "May cross-reference least agency / OWASP Agentic Top 10 ASI02 (Tool Misuse & Exploitation) and the tenant-isolation floor"
+  ],
+  "anti_behavior": [
+    "Approves the free-form run_query(sql) tool as fine",
+    "Accepts the system-prompt 'read-only, stay on-tenant' instruction as sufficient enforcement",
+    "Only adds input sanitization/escaping to the SQL string instead of removing the free-form tool shape",
+    "Treats tool output as trusted and ignores the tenant-isolation enforcement layer"
+  ],
+  "source": "references/agentic-ai-security.md §2 (least agency: bounded tools, args as a trust boundary, tool results untrusted) + §7 ASI02"
+}

--- a/evals/scenarios/agentic-mcp-server-review.json
+++ b/evals/scenarios/agentic-mcp-server-review.json
@@ -1,0 +1,20 @@
+{
+  "skills": ["senior-engineering-partner"],
+  "query": "We found a handy open-source MCP server on GitHub and we're about to connect it to our production agent so the agent can manage infrastructure. It runs over HTTP/SSE on our internal network (no auth — it's behind the VPN), and it exposes tools like `exec(command)` and `read_file(path)`. We'll pass it our cloud credentials as environment variables in the client config. Can you review whether this is safe to wire up?",
+  "files": [],
+  "expected_behavior": [
+    "Flags the transport/auth gap: a network (HTTP/SSE) MCP transport must authenticate — 'behind the VPN' is not authentication; no unauthenticated MCP endpoint beyond loopback, and it should enforce TLS and validate Origin",
+    "Flags overpermissioned tools: `exec(command)` and free-form `read_file(path)` are far broader than any single task needs — per-tool permission audit comparing claimed vs actual capability, and prefer narrow, purpose-scoped tools over arbitrary command/path execution",
+    "Flags input-validation/injection surface on every tool parameter (command injection via exec, path traversal / SSRF via read_file) and requires schemas that enforce types/enums instead of unrestricted strings",
+    "Flags the supply-chain risk: a third-party MCP server is a dependency — vet its source/maintenance, pin/verify it, and give it an independent review before granting it credentials (do not auto-update an unpinned server with tool access)",
+    "Flags the credential/config handling: cloud credentials should be least-privilege and referenced (resolved at exec time), not resolved into the client config; and warns that tool outputs/errors can leak secrets/PII back into model context (data-exposure)",
+    "May organize the review around the MCP-server-review dimensions and/or cross-reference agentic supply chain (OWASP Agentic Top 10 ASI04)"
+  ],
+  "anti_behavior": [
+    "Concludes the setup is safe because it's on the internal network / behind the VPN",
+    "Reviews only one dimension (e.g. mentions exec is risky) and misses the unauthenticated transport, the supply-chain vetting, or the credential exposure",
+    "Accepts passing cloud credentials as plain env vars in the config without least-privilege scoping or reference-based resolution",
+    "Treats the third-party server as trusted because it's popular/open-source, with no pin or independent review"
+  ],
+  "source": "references/local-and-agentic-ai-tools.md Part C (MCP-server review: transport/auth, tool-permission, injection, data-exposure, sandboxing, supply-chain, config) + agentic-ai-security.md §7 ASI04"
+}


### PR DESCRIPTION
Closes the eval gap from #105/#107: the agentic-AI security rules shipped without the regression scenarios that every other discipline in the skill carries. Three new `evals/scenarios/agentic-*.json`.

## Scenarios
| File | Guards | Rule |
|---|---|---|
| `agentic-human-in-loop-resolved-call` | a refund-issuing agent must gate the **resolved call** (not the narration), with idempotency + audit | agentic-ai-security.md §3; ASI09/ASI10 |
| `agentic-least-agency-tool-args` | reject a free-form `run_query(sql)` tool; constrain the tool, validate args as a trust boundary, tool results untrusted | §2; ASI02 |
| `agentic-mcp-server-review` | flag unauth transport, overpermission, injection, supply-chain, credential exposure across the 7 dimensions | local-and-agentic-ai-tools.md Part C; ASI04 |

## Sweep (opus, live)
| Scenario | Baseline (bare) | With-skill |
|---|---|---|
| human-in-loop-resolved-call | partial | **pass** |
| least-agency-tool-args | partial | **pass** |
| mcp-server-review | pass | pass |

**with-skill 3/3 pass; baseline 1 pass / 2 partial.** The skill lifts the two non-obvious behaviors (gating the resolved call; least-agency tool design) from partial → pass. **Honest note:** the MCP-review scenario is a baseline *pass* — the base model already reviews MCP servers reasonably — so it earns its keep as a regression guard rather than as demonstrated lift.

## Authoring note (per the eval discipline)
The `least-agency` scenario first came back **partial** with-skill. Root cause was a scenario bug, not a skill gap: one expected item bundled an SSRF/path/metadata-IP clause irrelevant to a SQL-only tool, so the judge graded it 'unclear'. Scoped the item to what the scenario exercises (SSRF/path coverage already lives in the MCP scenario's `read_file(path)` tool); re-ran → pass.

## Verification
Local gates green (leakage-guard, test-scripts.sh). `results/` is gitignored, so only the scenario JSONs are committed; tallies reported above.