### PR TITLE
fix(evals): isolate scenario and judge runs from the operator's global agent context

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -1,6 +1,6 @@
 # Evals for senior-engineering-partner
 
-Last updated: 2026-07-04 11:04 PM CDT
+Last updated: 2026-07-05 08:54 AM CDT
 
 A regression suite for the skill itself. Each scenario encodes a **real miss** the skill exists to
 prevent — most are drawn straight from the SKILL.md changelog — so the suite is the executable form of
@@ -100,6 +100,12 @@ reach. Scenario `query`s are first-party fixtures, but run sweeps only on a mach
 you trust with that. With-skill runs read a **staged copy** of the skill tree that excludes
 `evals/` (a run must never be able to read its own grading criteria) and the private,
 uncommitted files.
+
+Claude-runner scenario **and judge** runs are isolated from the invoking user's global agent
+context (`--setting-sources project`): user-level memory, hooks, and settings never load, so
+a sweep's "bare" responses can't absorb the operator's environment — the root cause of an
+identifier once leaking into a committed baseline. (Generic runners: the `--runner-cmd`
+template author owns the foreign CLI's equivalent isolation.)
 
 The judge receives two pieces of **harness-collected evidence** alongside the response text:
 the post-run **workspace evidence** (unified diffs vs the fixtures first, then new files —

--- a/scripts/run-evals.py
+++ b/scripts/run-evals.py
@@ -254,6 +254,11 @@ def run_claude(
         # baseline must not let a user-level install auto-activate.
         "--disallowedTools",
         "Skill",
+        # Isolation: never inherit the invoking user's global settings/hooks/memory —
+        # that context leaked an environment identifier into a committed "bare" baseline
+        # (scrubbed in #79). The temp cwd has no project settings, so this is a clean room.
+        "--setting-sources",
+        "project",
     ]
     if system_prompt is not None:
         cmd += ["--append-system-prompt", system_prompt]
@@ -289,6 +294,9 @@ def run_scenario_claude(
         "Skill",
         "--allowedTools",
         SCENARIO_ALLOWED_TOOLS,
+        # Same isolation as the judge path — see run_claude.
+        "--setting-sources",
+        "project",
     ]
     if system_prompt is not None:
         cmd += ["--append-system-prompt", system_prompt]


### PR DESCRIPTION
## What changed

Claude-runner scenario **and judge** invocations now pass `--setting-sources project`, so user-level memory, hooks, and settings never load into an eval run. `evals/README.md` documents the isolation (and notes that generic-runner template authors own their CLI's equivalent).

## Why it changed

A sweep's "bare" responses could absorb the operator's global agent context — the root cause of the environment identifier that leaked into a committed baseline (scrubbed in #79). This closes the hole at the harness level instead of relying on post-hoc scrubbing.

## Testing instructions

- `python3 -m py_compile scripts/run-evals.py` — passes.
- Recovered branch: authored 2026-07-05, rebased clean onto v1.23.0 `main` with zero conflicts (no commits on `main` since the branch point touch these hunks); CI gates validate the rest.

## Provenance note

This branch was found dangling (no PR) during repo cleanup — its worktree from the original session was stale/pruned. Opened from the existing remote tip; a force-push of the rebased-but-identical local tip was intentionally skipped.