### PR TITLE
feat(ci): reference-integrity + core-word-budget lint checks, and the eval-guard gate

### DIFF
--- a/.github/workflows/eval-guard.yml
+++ b/.github/workflows/eval-guard.yml
@@ -1,0 +1,31 @@
+name: eval-guard
+
+# A substantive SKILL.md rule change must ship a guarding eval scenario, or carry an
+# explicit `Eval-waiver: <reason>` line in the PR body — the mechanized form of the
+# self-improvement loop's guarding-eval contract (references/skill-self-improvement.md).
+# Metadata-only SKILL.md diffs (release-please Version/Last-updated rows) pass without a
+# waiver. Stdlib-only Python, so the local run and CI are byte-identical:
+# scripts/eval-guard.py. PR-only: the check needs a base to diff against.
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  eval-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Guard SKILL.md rule changes with evals
+        env:
+          BASE_REF: ${{ github.event.pull_request.base.sha }}
+          HEAD_REF: ${{ github.event.pull_request.head.sha }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          set -euo pipefail
+          python3 scripts/eval-guard.py

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,11 +1,17 @@
 # Evals for senior-engineering-partner
 
-Last updated: 2026-07-05 08:54 AM CDT
+Last updated: 2026-07-27 09:19 AM CDT
 
 A regression suite for the skill itself. Each scenario encodes a **real miss** the skill exists to
 prevent — most are drawn straight from the SKILL.md changelog — so the suite is the executable form of
 "this must never happen again." Anthropic's own most-emphasized authoring practice is *build evaluations
 first*; this brings the skill into line with it (the changelog was the spec; these are the tests).
+
+**The suite is gate-enforced, not aspirational:** the `eval-guard` CI check
+(`scripts/eval-guard.py`) fails any PR that makes a substantive SKILL.md change without touching
+`evals/scenarios/` — a rule change must ship its guarding eval, or the PR body must carry an
+explicit `Eval-waiver: <reason>` line (metadata-only diffs, e.g. release-please version bumps,
+pass automatically). Fixture-tested in `scripts/tests/test-scripts.sh` like every other gate.
 
 ## Why this exists
 

--- a/references/skill-self-improvement.md
+++ b/references/skill-self-improvement.md
@@ -39,7 +39,10 @@ Present all three parts — the human's yes/no gates everything that follows:
 2. **The guarding eval** — a new or extended `evals/` scenario whose
    `expected_behavior` / `anti_behavior` would have caught the original miss. A lesson
    without a guarding eval can silently regress; the scenario's `source` field records
-   the provenance.
+   the provenance. This contract is mechanized at the PR boundary: the `eval-guard` CI
+   gate (`scripts/eval-guard.py`) fails a substantive SKILL.md change that ships no
+   `evals/scenarios/` change, unless the PR body carries an explicit
+   `Eval-waiver: <reason>` line — an auditable decision, not a silent skip.
 3. **The origin story** — what happened, what it cost, and why the existing rules
    didn't cover it. This becomes the PR body's "why" and, at release time, changelog
    narrative material.

--- a/scripts/eval-guard.py
+++ b/scripts/eval-guard.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""eval-guard.py — a rule change to SKILL.md must ship a guarding eval, or say why not.
+
+The self-improvement loop (references/skill-self-improvement.md) requires that a new or
+sharpened rule arrive with a guarding eval scenario, but until this gate that arrival was
+post-hoc (the agentic-AI rules of v1.22.0 got their scenarios weeks later, in #108). This
+mechanizes the contract at the PR boundary:
+
+  PASS when any of:
+    - SKILL.md is not in the diff;
+    - the diff also touches evals/scenarios/ (a guarding eval rides along);
+    - the SKILL.md changes are metadata-only (the release-please Version row, the
+      Last-updated row, whitespace) — release PRs must not need waivers;
+    - the PR body carries an explicit waiver line:  Eval-waiver: <reason>
+      (an auditable decision, same posture as a dismissed review finding).
+  FAIL otherwise, naming the contract and the two ways to satisfy it.
+
+Inputs (all optional): $BASE_REF (default origin/main), $HEAD_REF (default HEAD) — the
+diff range is BASE_REF...HEAD_REF; $PR_BODY — the pull-request body to scan for a waiver.
+Stdlib-only; CI and a local run are byte-identical:
+  BASE_REF=origin/main PR_BODY="$(gh pr view --json body -q .body)" scripts/eval-guard.py
+Exit 0 = pass, 1 = fail, 2 = git plumbing error.
+"""
+from __future__ import annotations
+
+import os
+import re
+import subprocess
+import sys
+
+METADATA_LINE_RE = re.compile(
+    r"^[+-](\s*$"                                  # blank / whitespace-only
+    r"|\|\s*\*\*(Version|Last updated)\*\*\s*\|)"  # the two metadata table rows
+)
+WAIVER_RE = re.compile(r"^eval-waiver:\s*\S", re.IGNORECASE | re.MULTILINE)
+
+
+def git(*args: str) -> str:
+    """Run a git command and return stdout; exit 2 on plumbing failure."""
+    proc = subprocess.run(
+        ["git", *args], capture_output=True, text=True, check=False
+    )
+    if proc.returncode != 0:
+        print(f"FAIL: git {' '.join(args)}: {proc.stderr.strip()}", file=sys.stderr)
+        sys.exit(2)
+    return proc.stdout
+
+
+def main() -> int:
+    base = os.environ.get("BASE_REF", "origin/main")
+    head = os.environ.get("HEAD_REF", "HEAD")
+    rng = f"{base}...{head}"
+
+    changed = set(git("diff", "--name-only", rng).splitlines())
+    if "SKILL.md" not in changed:
+        print(f"PASS: eval-guard — SKILL.md untouched in {rng}")
+        return 0
+    if any(f.startswith("evals/scenarios/") for f in changed):
+        print("PASS: eval-guard — SKILL.md change ships with an evals/scenarios/ change")
+        return 0
+
+    diff_lines = git("diff", "-U0", rng, "--", "SKILL.md").splitlines()
+    substantive = [
+        line
+        for line in diff_lines
+        if (line.startswith("+") or line.startswith("-"))
+        and not line.startswith(("+++", "---"))
+        and not METADATA_LINE_RE.match(line)
+    ]
+    if not substantive:
+        print("PASS: eval-guard — SKILL.md changes are metadata-only (version/date rows)")
+        return 0
+
+    if WAIVER_RE.search(os.environ.get("PR_BODY", "")):
+        print(
+            "PASS: eval-guard — explicit Eval-waiver present in the PR body"
+            f" ({len(substantive)} substantive SKILL.md line(s) waived)"
+        )
+        return 0
+
+    print(
+        f"FAIL: eval-guard — {len(substantive)} substantive SKILL.md line(s) changed with"
+        " no evals/scenarios/ change. A rule change must ship its guarding eval"
+        " (references/skill-self-improvement.md), or the PR body must carry an explicit"
+        " 'Eval-waiver: <reason>' line.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/skill-lint.py
+++ b/scripts/skill-lint.py
@@ -13,6 +13,16 @@ AI tools"):
      repo has tripped over before — see CHANGELOG v1.1.0).
   4. Unknown frontmatter keys are WARNED, not failed (the spec allows optional fields;
      a typo'd required key still fails via checks 2-3).
+  5. Reference link integrity: every `references/<file>.md` path the SKILL.md body names
+     exists on disk, and every `references/*.md` file on disk is named somewhere in the
+     body (no dead pointers, no orphans a reader can never reach). The private
+     environment profile (`my-environment.md`) is exempt in both directions — it is
+     deliberately untracked, so it is absent in CI and unnamed-on-disk locally.
+  6. Core word budget: the SKILL.md body (frontmatter excluded) stays within
+     CORE_WORD_BUDGET words. The body is loaded wholesale into context on every
+     invocation, so its size is a per-session cost and an instruction-salience risk —
+     the budget is a RATCHET: it may be lowered as the core is compressed, never raised
+     without a maintainer decision recorded in the CHANGELOG.
 
 Exit 0 = all checks pass (warnings allowed). Exit 1 = any check failed.
 Usage: scripts/skill-lint.py [path-to-SKILL.md]
@@ -27,6 +37,14 @@ KNOWN_KEYS = {"name", "description", "license", "allowed-tools", "metadata", "ve
 NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 DESCRIPTION_LIMIT = 1024
 NAME_LIMIT = 64
+# Snapshot at v1.23.1 was 12,612 body words; headroom guards drift while the HIGH-1 core
+# diet is in flight, after which this ratchets DOWN (see the audit of 2026-07-27).
+CORE_WORD_BUDGET = 12_700
+CORE_WORD_WARN = 12_000
+# The private environment profile: named by SKILL.md but deliberately untracked (absent in
+# CI), and locally present but not required to be named — exempt from check 5 both ways.
+PRIVATE_REFS = {"my-environment.md"}
+REF_LINK_RE = re.compile(r"references/([A-Za-z0-9._-]+\.md)")
 
 
 def parse_frontmatter(text: str) -> dict[str, str] | None:
@@ -98,6 +116,37 @@ def main() -> int:
     for key in sorted(set(fields) - KNOWN_KEYS):
         warnings.append(f"unknown frontmatter key {key!r} (not failed; verify against the spec)")
 
+    # Check 5 — reference link integrity (both directions), rooted at the skill dir.
+    text = skill_path.read_text(encoding="utf-8")
+    body = re.sub(r"^---\r?\n.*?\r?\n---\r?\n", "", text, count=1, flags=re.S)
+    skill_dir = skill_path.resolve().parent
+    refs_dir = skill_dir / "references"
+    named = set(REF_LINK_RE.findall(body))
+    for ref in sorted(named - PRIVATE_REFS):
+        if not (refs_dir / ref).is_file():
+            failures.append(f"SKILL.md names references/{ref} but the file does not exist")
+    if refs_dir.is_dir():
+        on_disk = {p.name for p in refs_dir.glob("*.md")}
+        for ref in sorted(on_disk - named - PRIVATE_REFS):
+            failures.append(
+                f"references/{ref} exists but SKILL.md never names it (orphan — unreachable"
+                " by progressive disclosure; name it or remove it)"
+            )
+
+    # Check 6 — core word budget (ratchet; see module docstring).
+    words = len(body.split())
+    if words > CORE_WORD_BUDGET:
+        failures.append(
+            f"SKILL.md body is {words} words, over the CORE_WORD_BUDGET of"
+            f" {CORE_WORD_BUDGET} — compress to a reference trigger instead of growing the"
+            " always-loaded core (the budget only ratchets down)"
+        )
+    elif words > CORE_WORD_WARN:
+        warnings.append(
+            f"SKILL.md body is {words} words (> {CORE_WORD_WARN} warning floor,"
+            f" budget {CORE_WORD_BUDGET}) — nearing the core budget"
+        )
+
     for w in warnings:
         print(f"WARN: {w}", file=sys.stderr)
     if failures:
@@ -105,7 +154,8 @@ def main() -> int:
             print(f"FAIL: {f_}", file=sys.stderr)
         return 1
     print(
-        f"PASS: skill-lint — name OK, description {len(description)}/{DESCRIPTION_LIMIT} chars"
+        f"PASS: skill-lint — name OK, description {len(description)}/{DESCRIPTION_LIMIT} chars,"
+        f" body {words}/{CORE_WORD_BUDGET} words, {len(named - PRIVATE_REFS)} reference links OK"
         + (f", {len(warnings)} warning(s)" if warnings else "")
     )
     return 0

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -110,6 +110,82 @@ mkdir -p "$blockdir"
 rc=0; python3 "$repo_root/scripts/skill-lint.py" "$blockdir/SKILL.md" >/dev/null 2>&1 || rc=$?
 check "skill-lint FAILS on an oversize block-scalar description (bypass closed)" 1 "$rc"
 
+# Reference-integrity + core-budget checks (2026-07-27 audit): each planted violation must
+# FAIL; the conforming fixture above (no references, tiny body) already proves the PASS path.
+deadrefdir="$scratch/skill-fixture/deadref-skill"
+mkdir -p "$deadrefdir/references"
+printf -- '---\nname: deadref-skill\ndescription: "t"\n---\nRead references/does-not-exist.md.\n' \
+  > "$deadrefdir/SKILL.md"
+rc=0; python3 "$repo_root/scripts/skill-lint.py" "$deadrefdir/SKILL.md" >/dev/null 2>&1 || rc=$?
+check "skill-lint FAILS on a dead reference pointer" 1 "$rc"
+
+orphandir="$scratch/skill-fixture/orphan-skill"
+mkdir -p "$orphandir/references"
+printf 'never named\n' > "$orphandir/references/unreachable.md"
+printf -- '---\nname: orphan-skill\ndescription: "t"\n---\nbody with no reference links\n' \
+  > "$orphandir/SKILL.md"
+rc=0; python3 "$repo_root/scripts/skill-lint.py" "$orphandir/SKILL.md" >/dev/null 2>&1 || rc=$?
+check "skill-lint FAILS on an orphan reference file" 1 "$rc"
+
+# my-environment.md is exempt both ways: named-but-absent AND present-but-unnamed must pass.
+envdir="$scratch/skill-fixture/env-skill"
+mkdir -p "$envdir/references"
+printf 'private profile\n' > "$envdir/references/my-environment.md"
+printf -- '---\nname: env-skill\ndescription: "t"\n---\nRead references/my-environment.md early.\n' \
+  > "$envdir/SKILL.md"
+rc=0; python3 "$repo_root/scripts/skill-lint.py" "$envdir/SKILL.md" >/dev/null 2>&1 || rc=$?
+check "skill-lint PASSES the private-profile exemption (both directions)" 0 "$rc"
+
+budgetdir="$scratch/skill-fixture/budget-skill"
+mkdir -p "$budgetdir"
+{
+  printf -- '---\nname: budget-skill\ndescription: "t"\n---\n'
+  python3 -c "print('word ' * 12800)"
+} > "$budgetdir/SKILL.md"
+rc=0; python3 "$repo_root/scripts/skill-lint.py" "$budgetdir/SKILL.md" >/dev/null 2>&1 || rc=$?
+check "skill-lint FAILS a body over the core word budget" 1 "$rc"
+
+# --- eval-guard.py fixtures ------------------------------------------------------------------
+# A scratch git repo: base commit, then per-case head commits. The gate must FAIL a bare rule
+# change, and PASS each of its three documented outs (rides-with-eval, metadata-only, waiver).
+gitfix="$scratch/eval-guard-repo"
+mkdir -p "$gitfix/evals/scenarios"
+g() { git -C "$gitfix" -c user.email=t@t -c user.name=t -c commit.gpgsign=false "$@"; }
+git -C "$gitfix" init -q -b main
+printf -- '# rules\nold rule\n| **Version** | 1.0.0 |\n| **Last updated** | 2026-01-01 |\n' \
+  > "$gitfix/SKILL.md"
+g add SKILL.md && g commit -qm base
+base_sha="$(g rev-parse HEAD)"
+
+guard() { # guard <expected-exit> <desc> — runs eval-guard at current HEAD vs base
+  local expected="$1" desc="$2" body="${3-}"
+  local rc=0
+  (cd "$gitfix" && BASE_REF="$base_sha" HEAD_REF=HEAD PR_BODY="$body" \
+    python3 "$repo_root/scripts/eval-guard.py") >/dev/null 2>&1 || rc=$?
+  check "$desc" "$expected" "$rc"
+}
+
+printf -- '# rules\nNEW RULE with no eval\n| **Version** | 1.0.0 |\n| **Last updated** | 2026-01-01 |\n' \
+  > "$gitfix/SKILL.md"
+g commit -qam "rule change, no eval"
+guard 1 "eval-guard FAILS a bare SKILL.md rule change"
+guard 0 "eval-guard PASSES the same change with an Eval-waiver body" \
+  $'What changed\nEval-waiver: prose reorder only, no behavior change'
+
+printf '{}\n' > "$gitfix/evals/scenarios/new-rule.json"
+g add evals/scenarios/new-rule.json && g commit -qm "add guarding eval"
+guard 0 "eval-guard PASSES a rule change that ships its guarding eval"
+
+g reset -q --hard "$base_sha"
+printf -- '# rules\nold rule\n| **Version** | 1.1.0 |\n| **Last updated** | 2026-02-02 |\n' \
+  > "$gitfix/SKILL.md"
+g commit -qam "release metadata only"
+guard 0 "eval-guard PASSES a metadata-only SKILL.md diff (release PR shape)"
+
+g reset -q --hard "$base_sha"
+g commit -q --allow-empty -m "no skill change"
+guard 0 "eval-guard PASSES when SKILL.md is untouched"
+
 # --- run-evals.py runner plumbing (offline: pure logic + argparse fail-fast; no model runs) --
 # build_runner_cmd is the injection boundary for --runner generic: placeholders substitute
 # AFTER shell-style tokenization, so a hostile prompt must stay ONE argv token.


### PR DESCRIPTION
## What changed

**skill-lint.py** gains two check families (audit 2026-07-27, LOW-6 + HIGH-1 enforcement half):
- **Reference link integrity, both directions** — every `references/*.md` the SKILL.md body names must exist; every reference file on disk must be named in the body (no dead pointers, no orphans unreachable by progressive disclosure). `my-environment.md` is exempt both ways (deliberately untracked private profile) — proven by fixture.
- **Core word budget (ratchet)** — the SKILL.md body must stay ≤ `CORE_WORD_BUDGET` (12,700 now; snapshot at v1.23.1 is 12,490 body words + drift headroom; warning floor 12,000). The budget only ratchets down — the HIGH-1 core diet will lower it.

**eval-guard** (new CI check + `scripts/eval-guard.py`, audit MEDIUM-3): a substantive SKILL.md change must ship an `evals/scenarios/` change or an explicit `Eval-waiver: <reason>` line in the PR body. Metadata-only diffs (release-please Version/Last-updated rows) pass automatically, so release PRs need no waiver. This mechanizes the self-improvement loop's guarding-eval contract, which until now arrived post-hoc (#108 backfilled the v1.22.0 agentic rules weeks later).

Docs in the same commit: `evals/README.md` (gate note + stamp), `references/skill-self-improvement.md` (contract now names its mechanization).

## Why it changed

2026-07-27 audit findings MEDIUM-3 and LOW-6: the guarding-eval mandate and the reference-hygiene checks were policy without enforcement — this converts both to required-check-able gates, per the repo's own 'gates, not advice' posture.

## Testing instructions

- `scripts/tests/test-scripts.sh`: **29 passed, 0 failed** — including planted-violation fixtures for every new check (dead pointer, orphan, over-budget, private-profile exemption, and all four eval-guard paths: bare rule change FAILS, rides-with-eval / metadata-only / waiver PASS).
- `shellcheck` clean on the test script; both Python scripts stdlib-only and `py_compile` clean.
- Extended skill-lint run against the real SKILL.md: PASS (body 12,490/12,700 words, 44 reference links OK, 1 expected nearing-budget warning).

Once green, `eval-guard` should be added to the required checks in the main ruleset (maintainer call, per the promotion-is-never-default rule).