### PR TITLE
docs: require the Fable model for authoring in this repo

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,8 +9,8 @@ and `MAINTAINERS.md` — this file is the agent-facing distillation.
 **All authoring in this repo is done with the Fable model (`claude-fable-5`).**
 Reading, auditing, and *proposing* changes are fine on any model; **writing** to
 `SKILL.md`, `references/`, `scripts/`, `evals/`, or the repo docs is not. On any
-other model, say so and stop before editing — offer to switch (`/model
-claude-fable-5`) or resume in a Fable session. Proceed otherwise only on an
+other model, say so and stop before editing — offer to switch
+(`/model claude-fable-5`) or resume in a Fable session. Proceed otherwise only on an
 express, per-change instruction from the maintainer; a general "go ahead"
 earlier in the session is not one. Rationale: the skill's authored content
 stays consistent in voice, judgment, and rule-wording instead of drifting with

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,18 @@ Agent/contributor guide for working **on** this repo (the skill itself lives
 in `SKILL.md` + `references/`). Human-facing process docs: `CONTRIBUTING.md`
 and `MAINTAINERS.md` — this file is the agent-facing distillation.
 
+## Model requirement (read before editing anything)
+
+**All authoring in this repo is done with the Fable model (`claude-fable-5`).**
+Reading, auditing, and *proposing* changes are fine on any model; **writing** to
+`SKILL.md`, `references/`, `scripts/`, `evals/`, or the repo docs is not. On any
+other model, say so and stop before editing — offer to switch (`/model
+claude-fable-5`) or resume in a Fable session. Proceed otherwise only on an
+express, per-change instruction from the maintainer; a general "go ahead"
+earlier in the session is not one. Rationale: the skill's authored content
+stays consistent in voice, judgment, and rule-wording instead of drifting with
+whichever model happens to be loaded.
+
 ## Repo shape
 
 - `SKILL.md` — the universal core; `references/` — deep-dive references


### PR DESCRIPTION
## What changed

One new section at the top of `CLAUDE.md` — **Model requirement (read before editing anything)** — recording that all authoring in this repo is done with the Fable model (`claude-fable-5`). Reading, auditing, and *proposing* changes stay model-agnostic; **writing** to `SKILL.md`, `references/`, `scripts/`, `evals/`, or the repo docs does not. On any other model, an agent must stop and flag before editing; deviating requires an express, per-change instruction from the maintainer.

12 added lines, one file. No other surface touched.

## Why it changed

Standing instruction from the maintainer (2026-08-06): the skill's authored content should come from one consistent model rather than drifting in voice, judgment, and rule-wording across whichever model happens to be loaded — and the maintainer asked to be actively protected from doing it by accident, so the burden sits on the agent to raise it.

`CLAUDE.md` is the right home: it is the agent-facing distillation, and it is picked up by any agent working in this repo regardless of which project memory is loaded. A memory entry alone only protects sessions that load that memory.

## Testing instructions

- `scripts/skill-lint.py` → **PASS** (name OK, description 979/1024 chars, body 12490/12700 words, 44 reference links OK; 1 pre-existing warning that the core is nearing its word budget — this change does not touch `SKILL.md`).
- Mermaid render-check: **N/A** — `CLAUDE.md` contains no Mermaid blocks (`grep -c '```mermaid'` → 0).
- Commit is SSH-signed and verifies (`git log -1 --format='%G?'` → `G`).
- No CHANGELOG/version edit: per `CLAUDE.md` → *PR rules*, release-please derives both from the Conventional Commit.

### Local Tier-2 denylist noise (NOT a gate failure, NOT introduced here)

`scripts/leakage-guard.sh` exits **1 on my machine** — and identically on `main`, verified by checking `main` out and re-running — while **CI's `leakage-guard` passes**. That divergence is the script's documented two-tier design, not a broken gate: `leakage-guard.sh:15` states that CI, having no un-committed `references/leakage-denylist.local`, enforces only the generic Tier-1 patterns. The 4 findings come from the private Tier-2 list and are all in committed eval baselines, none in this diff:

| File | Matched substring |
|---|---|
| `evals/baselines/2026-07-27-opus/with-skill.json:771` | `forensic` |
| `evals/baselines/2026-07-27-opus/with-skill.json:788` | `forensic` |
| `evals/baselines/2026-07-27-postdiet-experiment/opus-with-skill.json:657` | `chain-of-custody` |
| `evals/baselines/2026-07-27-postdiet-experiment/opus-with-skill.json:1601` | `forensic` |

The committed tree is clean under the shared denylist, so nothing is leaking publicly. But the baselines use both terms as generic engineering vocabulary (debugging forensics; cryptographic chain-of-custody), which means **the maintainer's local pre-push guard now fails on every branch regardless of its diff** — the condition that trains a reviewer to wave the guard through. Worth fixing as its own change: narrow the two Tier-2 patterns, or scope-exclude `evals/baselines/`. Out of scope here.

## Review verdict

**Structured self-review recorded** (per `CLAUDE.md` → *PR rules*). Reviewed dimensions:

- **Correctness / scope:** diff is 12 added lines in one file; `git status` shows no stray changes swept in.
- **Security:** documentation only — no code, no gate, no credential, no execution path touched.
- **Leakage:** the added text names only a model id and repo paths; no employer, host, domain, or private identifier. The guard's 4 findings are pre-existing and unrelated (table above).
- **Discipline compliance:** this **adds** a constraint and relaxes nothing, so it satisfies the self-improvement loop's add-or-sharpen-only invariant. It is process guidance for contributors, not a skill discipline, so it needs no guarding eval under `references/skill-self-improvement.md` §2.
- **Self-consistency note:** this change was authored on **Opus 5**, not Fable — under the express per-change exception the new rule itself defines, granted by the maintainer for exactly this edit. Flagging it explicitly so the record is honest rather than quietly self-exempting.

Requires 1 approval; the author cannot self-approve.
