### PR TITLE
fix: scope hand-authored-only denylist patterns away from recorded baselines

### DIFF
--- a/references/leakage-denylist.local.template
+++ b/references/leakage-denylist.local.template
@@ -14,6 +14,12 @@
 # Escape regex metacharacters (a literal dot is \. ). Use \b...\b word boundaries for short tokens
 # that would otherwise match inside ordinary words.
 #
+# Sections: a line containing exactly `[hand-authored-only]` starts a section whose patterns are
+# enforced everywhere EXCEPT evals/baselines/ (recorded model outputs). Put broad DOMAIN-
+# FINGERPRINT words there — generic English that merely hints at what you're building and
+# legitimately recurs in baseline transcripts. Literal identifiers (hosts, employer, repo names)
+# stay ABOVE the section line: a baseline containing a real hostname is still a leak.
+#
 # Replace everything below with your own, then delete these examples:
 
 # Hosts / machines
@@ -38,3 +44,8 @@
 
 # Personal email prefix (attribution should use your website/handle, not an address)
 # me@
+
+# [hand-authored-only]
+# Broad product-domain words (enforced in hand-authored files; exempt in evals/baselines/)
+# widgetization
+# supply[-. ]chain[-. ]auditing

--- a/references/leakage-denylist.local.template
+++ b/references/leakage-denylist.local.template
@@ -45,7 +45,10 @@
 # Personal email prefix (attribution should use your website/handle, not an address)
 # me@
 
-# [hand-authored-only]
+# The directive below is deliberately UNcommented so the section works as soon as you add
+# patterns under it (a commented-out directive is an easy trap — Copilot review, PR #125).
+# The guard never reads this template, only your .local copy.
+[hand-authored-only]
 # Broad product-domain words (enforced in hand-authored files; exempt in evals/baselines/)
 # widgetization
 # supply[-. ]chain[-. ]auditing

--- a/scripts/leakage-guard.sh
+++ b/scripts/leakage-guard.sh
@@ -49,8 +49,10 @@ section='all'
 if [[ -f "$local_list" ]]; then
   while IFS= read -r frag; do
     frag="${frag%$'\r'}"                                 # strip a trailing CR
-    if [[ "$frag" =~ ^\[hand-authored-only\][[:space:]]*$ ]]; then
-      section='ho'; continue                             # section directive, not a pattern
+    # Section directive — whitespace-tolerant: an indented directive treated as a pattern
+    # would be an ERE *character class* matching nearly every line (Copilot review, PR #125).
+    if [[ "$frag" =~ ^[[:space:]]*\[hand-authored-only\][[:space:]]*$ ]]; then
+      section='ho'; continue
     fi
     [[ "$frag" =~ ^[[:space:]]*(#.*)?$ ]] && continue    # skip blank / comment lines
     frag="${frag#"${frag%%[![:space:]]*}"}"              # ltrim

--- a/scripts/leakage-guard.sh
+++ b/scripts/leakage-guard.sh
@@ -22,6 +22,14 @@
 # SKILL.md's metadata table — matched out below. references/my-environment.md and
 # references/leakage-denylist.local are never scanned (the latter has a non-scanned extension).
 #
+# Tier-2 sectioning: a `[hand-authored-only]` line in the .local file starts a section whose
+# patterns are enforced everywhere EXCEPT evals/baselines/ (recorded model outputs). Rationale:
+# broad domain-fingerprint words (generic English that merely *hints* at a product domain)
+# recur legitimately in baseline transcripts whose sanitized scenarios use that vocabulary —
+# an every-branch false positive that trains reviewers to wave the guard through. Literal
+# identifiers (hosts, employer, repo names) stay in the default section: those are enforced in
+# baselines too, because a baseline containing a real hostname IS a leak.
+#
 # Usage:  scripts/leakage-guard.sh
 set -euo pipefail
 
@@ -33,15 +41,25 @@ denylist='100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\.[0-9]{1,3}\.[0-9]{1,3}'  
 denylist+='|\[\[[A-Za-z]'   # [[wikilink]] — NOT a Bash [[ test (which has a space after [[)
 
 # --- Tier 2: your private LITERAL identifiers, sourced from an un-committed file (if present).
-#     One POSIX-ERE fragment per line; '#' lines and blanks are ignored.
+#     One POSIX-ERE fragment per line; '#' lines and blanks are ignored. A `[hand-authored-only]`
+#     line starts the section whose patterns skip evals/baselines/ (see header).
 local_list="references/leakage-denylist.local"
+denylist_ho=''   # [hand-authored-only] patterns — enforced everywhere except evals/baselines/
+section='all'
 if [[ -f "$local_list" ]]; then
   while IFS= read -r frag; do
     frag="${frag%$'\r'}"                                 # strip a trailing CR
+    if [[ "$frag" =~ ^\[hand-authored-only\][[:space:]]*$ ]]; then
+      section='ho'; continue                             # section directive, not a pattern
+    fi
     [[ "$frag" =~ ^[[:space:]]*(#.*)?$ ]] && continue    # skip blank / comment lines
     frag="${frag#"${frag%%[![:space:]]*}"}"              # ltrim
     frag="${frag%"${frag##*[![:space:]]}"}"              # rtrim
-    denylist+="|${frag}"
+    if [[ "$section" == 'ho' ]]; then
+      denylist_ho+="${denylist_ho:+|}${frag}"
+    else
+      denylist+="|${frag}"
+    fi
   done < "$local_list"
 else
   # A missing local list silently downgrades this run to Tier-1 only — say so loudly, so a
@@ -71,15 +89,22 @@ allow='Brian Greenberg|briangreenberg\.net'
 hits=0
 for f in "${files[@]}"; do
   [[ -f "$f" ]] || continue
+  # Effective pattern for THIS file: recorded eval baselines are exempt from the
+  # [hand-authored-only] section; every other file gets both sections.
+  eff="$denylist"
+  case "$f" in
+    evals/baselines/*|./evals/baselines/*) ;;
+    *) if [[ -n "$denylist_ho" ]]; then eff+="|${denylist_ho}"; fi ;;
+  esac
   while IFS= read -r line; do
     # Strip the allowed-attribution substrings, then test the remainder for denylist tokens.
     stripped="$(printf '%s' "$line" | sed -E "s/${allow}//g")"
-    if printf '%s' "$stripped" | grep -qEi "$denylist"; then
+    if printf '%s' "$stripped" | grep -qEi "$eff"; then
       if [[ "$hits" -eq 0 ]]; then echo "LEAKAGE-GUARD: environment-specific identifiers found:" >&2; fi
       printf '  %s: %s\n' "$f" "$line" >&2
       hits=$((hits + 1))
     fi
-  done < <(grep -nEi "$denylist" "$f" || true)
+  done < <(grep -nEi "$eff" "$f" || true)
 done
 
 if [[ "$hits" -ne 0 ]]; then

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -80,6 +80,36 @@ check "leakage-guard PASSES on a clean tree" 0 "$rc"
 rc=0; grep -q "Tier 1 only" <<<"$out" || rc=$?
 check "leakage-guard WARNs Tier-1-only when the .local denylist is absent" 0 "$rc"
 
+# (c) Tier-2 sectioning: [hand-authored-only] patterns are exempt in evals/baselines/ but
+# enforced in hand-authored files; default-section identifiers stay enforced EVERYWHERE.
+# Patterns here are synthetic words in no real denylist, so literals are safe in this file.
+sectdir="$scratch/guard-sectioned"
+make_guard_fixture "$sectdir"
+mkdir -p "$sectdir/evals/baselines"
+{
+  echo "plutonium-project"          # default section: a literal identifier
+  echo "[hand-authored-only]"
+  echo "fictionology"               # domain-fingerprint word: baseline-exempt
+} > "$sectdir/references/leakage-denylist.local"
+printf '{"evidence": "the fictionology angle held"}\n' > "$sectdir/evals/baselines/run.json"
+printf '# doc\nclean prose here.\n' > "$sectdir/README.md"
+git -C "$sectdir" add -A
+rc=0; (cd "$sectdir" && bash scripts/leakage-guard.sh) >/dev/null 2>&1 || rc=$?
+check "leakage-guard PASSES a hand-authored-only word inside evals/baselines/" 0 "$rc"
+
+# ...the same word in a hand-authored file must still FAIL.
+printf 'notes on the fictionology approach\n' > "$sectdir/README.md"
+git -C "$sectdir" add -A
+rc=0; (cd "$sectdir" && bash scripts/leakage-guard.sh) >/dev/null 2>&1 || rc=$?
+check "leakage-guard FAILS the same word in a hand-authored file" 1 "$rc"
+
+# ...and a default-section identifier inside evals/baselines/ must still FAIL.
+printf '# doc\nclean prose here.\n' > "$sectdir/README.md"
+printf '{"evidence": "ran on plutonium-project last week"}\n' > "$sectdir/evals/baselines/run.json"
+git -C "$sectdir" add -A
+rc=0; (cd "$sectdir" && bash scripts/leakage-guard.sh) >/dev/null 2>&1 || rc=$?
+check "leakage-guard FAILS a default-section identifier inside evals/baselines/" 1 "$rc"
+
 # --- skill-lint.py fixtures ------------------------------------------------------------------
 lintdir="$scratch/skill-fixture/good-skill"
 mkdir -p "$lintdir"

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -88,7 +88,7 @@ make_guard_fixture "$sectdir"
 mkdir -p "$sectdir/evals/baselines"
 {
   echo "plutonium-project"          # default section: a literal identifier
-  echo "[hand-authored-only]"
+  echo "  [hand-authored-only]  "   # INDENTED on purpose: directive must be whitespace-tolerant
   echo "fictionology"               # domain-fingerprint word: baseline-exempt
 } > "$sectdir/references/leakage-denylist.local"
 printf '{"evidence": "the fictionology angle held"}\n' > "$sectdir/evals/baselines/run.json"


### PR DESCRIPTION
## What changed

`scripts/leakage-guard.sh` gains a `[hand-authored-only]` section in the Tier-2 `.local` denylist: patterns in that section are enforced everywhere **except** `evals/baselines/` (recorded model outputs). Patterns above the section line — literal identifiers — stay enforced in baselines too. The `.local.template` documents the section; `scripts/tests/test-scripts.sh` adds three fixtures proving both directions of the boundary (suite now 37/37).

## Why it changed

Four broad domain-fingerprint patterns in the maintainer's private denylist matched generic engineering vocabulary in committed eval baselines, so the local pre-PR guard failed on **every branch regardless of its diff** (documented in PR #124) — the condition that trains a reviewer to wave a failing gate through. The fingerprint patterns exist to keep domain-hinting prose out of hand-authored files; recorded baseline transcripts legitimately use that vocabulary because the sanitized eval scenarios do. This scopes the pattern class to where its threat model applies, without weakening identifier enforcement anywhere. CI behavior is unchanged (CI has no `.local` file; Tier-1 only).

## Testing instructions

- `bash scripts/tests/test-scripts.sh` → 37 passed, 0 failed (3 new: HO-word-in-baseline passes; same word in README fails; identifier-in-baseline fails)
- `shellcheck scripts/leakage-guard.sh scripts/tests/test-scripts.sh` → clean
- Against the maintainer's **real** `.local` (typo-in-section-header check): clean tree passes; planted `forensic` in README.md → exit 1; planted hostname in a baseline → exit 1; both restored, `git status` clean of strays.

## Review verdict

Structured self-review recorded: no relaxation of the shipped gate (CI path untouched; the sectioning only affects the optional local tier, and only for the file class whose false positives were systemic); `set -e` safety on the new conditional uses `if`, not an `&&` tail; bash-3.2-compatible (no mapfile/assoc arrays); fixture patterns are synthetic words so this file can't trip the real guard. Authored on Fable per CLAUDE.md's model requirement.