### PR TITLE
docs: correct evals baseline narrative + required-check lists (audit HIGH-1..3)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ may not be checkable enough yet.
   every review thread addressed or resolved. We don't merge on green CI alone: green proves the
   *gates* passed, not that the change is correct, in-scope, and free of a subtle regression a check
   didn't cover.
-- The repo's **required checks** (`docs-render`, `leakage-guard`, `shellcheck`, `skill-lint`, `script-tests`, `citation-validate`) must pass.
+- The repo's **required checks** (`docs-render`, `leakage-guard`, `shellcheck`, `skill-lint`, `script-tests`, `citation-validate`, `eval-guard`) must pass. **`eval-guard` means a substantive `SKILL.md` change must ship a change under `evals/scenarios/` in the same PR** — a discipline needs a guarding eval — or carry an explicit `Eval-waiver: <reason>` line in the PR body (an auditable deferral, e.g. batching several scenarios into one re-baseline sweep — never a silent skip).
 - Merges are **squash-only** — rebase-merge (it rewrites your commits *unsigned*) and merge-commit
   are both disabled — and the branch is auto-deleted on merge. GitHub signs the squash commit, so
   your contribution lands **Verified** on `main` even if your own commits weren't signed; you don't

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,7 +7,9 @@ This project is maintained by:
 ## How we work
 
 - Every change lands via a pull request with the required checks green (`docs-render`, `leakage-guard`,
-  `shellcheck`, `skill-lint`, `script-tests`, `citation-validate`) and a maintainer review — see [CONTRIBUTING.md](CONTRIBUTING.md).
+  `shellcheck`, `skill-lint`, `script-tests`, `citation-validate`, `eval-guard`) and a maintainer review — see [CONTRIBUTING.md](CONTRIBUTING.md).
+  (`eval-guard`: a substantive `SKILL.md` change ships an `evals/scenarios/` change in the same PR, or an
+  explicit `Eval-waiver: <reason>` line in the PR body.)
 - The branch ruleset requires **1 approving review**. The maintainer (repo admin) can self-merge
   their *own* PRs via an admin bypass, so a solo merge is never blocked — while every *other*
   contributor's PR gets a genuine four-eyes review before it lands.

--- a/evals/README.md
+++ b/evals/README.md
@@ -206,10 +206,26 @@ judge reasons, with the response transcripts stripped — plus a `BASELINE.md` s
 headline numbers, the per-scenario gap table, and the harness caveats. Record one **before
 any large core edit** and validate the edit by re-running **both** modes under the same
 harness afterward; a baseline only covers the scenarios that existed when it was taken
-(added/edited scenarios re-baseline on the next sweep). **Current (harness v2, the only
-comparable record):** [`baselines/2026-07-05-opus/`](baselines/2026-07-05-opus/BASELINE.md) —
-bare 11/22/12/0 vs with-skill **29/16/0/0**: 23 of 45 improved, 0 regressed, and the
-with-skill fail column is zero for the first time on any recorded sweep. Historical
+(added/edited scenarios re-baseline on the next sweep). **Current (harness v2, 56-scenario
+suite, recorded 2026-07-27/28):**
+[`baselines/2026-07-27-opus/`](baselines/2026-07-27-opus/BASELINE.md) — bare 15/28/13/0 vs
+with-skill **42/13/1/0**;
+[`baselines/2026-07-28-fable/`](baselines/2026-07-28-fable/BASELINE.md) — bare 9/30/17/0 vs
+with-skill **42/14/0/0**, the first zero-fail with-skill sweep on the full suite;
+[`baselines/2026-07-27-haiku/`](baselines/2026-07-27-haiku/BASELINE.md) — bare 1/21/34/0 vs
+with-skill 13/28/15/0 (content transfers down-model; enforcement reliability does not).
+[`baselines/2026-07-27-postdiet-experiment/`](baselines/2026-07-27-postdiet-experiment/EXPERIMENT.md)
+is the core-density control record — future core-compression edits compare against it, not
+against post-t4. **The current sharpening picture (read from these records, not the older
+narrative):** no scenario fails on all three models any more. Opus's single with-skill fail
+is `adversarial-review-green-but-insufficient`; Fable's fail column is zero; Haiku's 15
+fails are an enforcement-reliability gap, not content gaps — the old durable-fail trio
+(dependency-manifest-drift · stale-diagram-on-behavior-change · tdd-regression-red-first)
+now passes on Opus, and only `dependency-manifest-drift` still runs partial on
+Fable/Haiku. Sharpening effort goes to the adversarial-review scenario and Haiku
+enforcement, not the solved trio. Prior harness-v2 record (45-scenario era, superseded as
+"current"): [`baselines/2026-07-05-opus/`](baselines/2026-07-05-opus/BASELINE.md) —
+bare 11/22/12/0 vs with-skill 29/16/0/0. Historical
 (pre-discontinuity, not comparable — see the note below):
 [`baselines/2026-07-02-opus/`](baselines/2026-07-02-opus/BASELINE.md) — the skill improves
 20 of 38 scenarios over the bare model with zero regressions (fails 13→4) — plus the
@@ -217,19 +233,17 @@ per-model portability sweeps of 2026-07-04:
 [`baselines/2026-07-04-fable/`](baselines/2026-07-04-fable/BASELINE.md) — 22 of 45
 improved, 0 regressed (fails 9→3, pass 8→28: the skill's value compounds up-model) —
 [`baselines/2026-07-04-sonnet/`](baselines/2026-07-04-sonnet/BASELINE.md) — 14 of 45
-improved, 0 regressed (fails 12→7; four of the seven remaining fails are the same durable
-fails Opus records, i.e. content gaps, not model gaps) — and
+improved, 0 regressed (fails 12→7; four of the seven remaining fails were the same durable
+fails Opus recorded then, i.e. content gaps, not model gaps) — and
 [`baselines/2026-07-04-haiku/`](baselines/2026-07-04-haiku/BASELINE.md) — the skill improves
 15 of 45 scenarios on Haiku 4.5 (fails 23→16), but 15 scenarios stay failed with the skill
 loaded, where Opus left 4: the content transfers down-model, the enforcement reliability
-does not. Across the four recorded sweeps, with-skill fails run 16 (Haiku) → 7 (Sonnet) →
-4 (Opus, older suite) → 3 (Fable) with identical skill text — the shared durable-fail core
-(dependency-manifest-drift · stale-diagram-on-behavior-change · tdd-regression-red-first)
-is the standing sharpening target. The tranche-4 core compression (~18% of SKILL.md,
-rules-lossless) was validated against those pre-edit references the same day —
+does not. (The durable-fail trio those sweeps identified was closed by later releases —
+see the current sharpening picture above.) The tranche-4 core compression (~18% of
+SKILL.md, rules-lossless) was validated against those pre-edit references the same day —
 [`baselines/2026-07-04-post-t4/`](baselines/2026-07-04-post-t4/BASELINE.md): no drop on any
-model traces to lost text; future core edits compare with-skill runs against the post-t4
-record. Superseded:
+model traces to lost text; post-t4 served as the core-edit comparison record until the
+2026-07-27 postdiet-experiment control superseded it. Superseded:
 [`baselines/2026-07-01-opus/`](baselines/2026-07-01-opus/BASELINE.md) (31 scenarios @ v1.8.0).
 
 > **Harness discontinuity (2026-07-04, the fixture/tool-grant change).** Every baseline above —

--- a/evals/README.md
+++ b/evals/README.md
@@ -221,9 +221,10 @@ narrative):** no scenario fails on all three models any more. Opus's single with
 is `adversarial-review-green-but-insufficient`; Fable's fail column is zero; Haiku's 15
 fails are an enforcement-reliability gap, not content gaps — the old durable-fail trio
 (dependency-manifest-drift · stale-diagram-on-behavior-change · tdd-regression-red-first)
-now passes on Opus, and only `dependency-manifest-drift` still runs partial on
-Fable/Haiku. Sharpening effort goes to the adversarial-review scenario and Haiku
-enforcement, not the solved trio. Prior harness-v2 record (45-scenario era, superseded as
+now passes on Opus, and of that trio only `dependency-manifest-drift` still runs partial
+on Fable/Haiku (`stale-diagram-on-behavior-change` also fails on Haiku, inside Haiku's
+broader enforcement gap). Sharpening effort goes to the adversarial-review scenario and
+Haiku enforcement, not the solved trio. Prior harness-v2 record (45-scenario era, superseded as
 "current"): [`baselines/2026-07-05-opus/`](baselines/2026-07-05-opus/BASELINE.md) —
 bare 11/22/12/0 vs with-skill 29/16/0/0. Historical
 (pre-discontinuity, not comparable — see the note below):


### PR DESCRIPTION
## What changed
- **evals/README.md**: the "Current" record is now the 2026-07-27/28 trio (Opus 42/13/1 · Fable 42/14/0, first zero-fail full-suite sweep · Haiku 13/28/15) with the postdiet-experiment named as the core-edit control; the 2026-07-05 sweep is re-labeled prior-record (45-scenario era). The stale durable-fail-trio "standing sharpening target" is retired and replaced with the verified current picture: no all-model fail exists; Opus's one fail is `adversarial-review-green-but-insufficient`; Haiku's 15 fails are enforcement reliability.
- **CONTRIBUTING.md / MAINTAINERS.md**: required-check lists gain `eval-guard` (live in ruleset 18154173 since #117 — verified via `gh api .../rules/branches/main`, 7 contexts) with the guarding-eval obligation and the `Eval-waiver:` escape hatch documented for contributors.

## Why
Docs audit (::: SKILL ::: session, 2026-08-08, handed off by Brian), findings HIGH-1..3: the narrative pointed sharpening effort at solved problems and contributors couldn't learn the eval obligation from the docs. Every audit claim was independently re-verified before editing (tallies from the baseline JSONs; trio status per model; live ruleset contexts).

## Testing
Baseline links in the rewritten narrative resolve (mechanical check, zero dead) · `leakage-guard` Tier 1+2 PASS · `test-scripts` 37/37 · no SKILL.md change → no eval obligation.

## Review verdict
Self-review recorded: numbers copied from the JSON tallies, not prose memory; the retired trio is described as retired (append-style honesty) rather than deleted from history; the 2026-07-04 sweep paragraphs keep their era-correct claims with tense fixes only. Authored on Fable.