### PR TITLE
feat: mechanize README↔tree documentation integrity (audit LOW-11)

### DIFF
--- a/scripts/skill-lint.py
+++ b/scripts/skill-lint.py
@@ -23,6 +23,11 @@ AI tools"):
      invocation, so its size is a per-session cost and an instruction-salience risk —
      the budget is a RATCHET: it may be lowered as the core is compressed, never raised
      without a maintainer decision recorded in the CHANGELOG.
+  7. README documentation integrity (only when a README.md sits beside SKILL.md):
+     every `references/*.md` on disk and every helper in `scripts/` (top-level .sh/.py/
+     .md) is NAMED somewhere in the README — the catalogue/prose must not silently lag
+     the tree (the 2026-08-08 docs audit found two references and four scripts missing;
+     this is that audit's LOW-11 "mechanize it", the same move that created check 5).
 
 Exit 0 = all checks pass (warnings allowed). Exit 1 = any check failed.
 Usage: scripts/skill-lint.py [path-to-SKILL.md]
@@ -37,8 +42,10 @@ KNOWN_KEYS = {"name", "description", "license", "allowed-tools", "metadata", "ve
 NAME_RE = re.compile(r"^[a-z0-9]+(-[a-z0-9]+)*$")
 DESCRIPTION_LIMIT = 1024
 NAME_LIMIT = 64
-# Snapshot at v1.23.1 was 12,612 body words; headroom guards drift while the HIGH-1 core
-# diet is in flight, after which this ratchets DOWN (see the audit of 2026-07-27).
+# A CEILING against unbounded growth, not a diet target: the tranche-5 core diet was
+# REFUTED by its own eval sweep (docs/adr/0001-core-density-over-token-cost.md) — the
+# core keeps its density, and any future compression pays section-by-section against
+# that section's guarding scenarios. Raise only via a recorded maintainer decision.
 CORE_WORD_BUDGET = 12_700
 CORE_WORD_WARN = 12_000
 # The private environment profile: named by SKILL.md but deliberately untracked (absent in
@@ -132,6 +139,32 @@ def main() -> int:
                 f"references/{ref} exists but SKILL.md never names it (orphan — unreachable"
                 " by progressive disclosure; name it or remove it)"
             )
+
+    # Check 7 — README documentation integrity (see module docstring). Conditional on a
+    # README existing beside SKILL.md so fixture skills without one still lint clean.
+    readme_path = skill_dir / "README.md"
+    if readme_path.is_file():
+        readme = readme_path.read_text(encoding="utf-8")
+        if refs_dir.is_dir():
+            for ref in sorted({p.name for p in refs_dir.glob("*.md")} - PRIVATE_REFS):
+                if ref not in readme:
+                    failures.append(
+                        f"references/{ref} exists but README.md never names it — update the"
+                        " reference catalogue (a doc that lags the tree is a wrong doc)"
+                    )
+        scripts_dir = skill_dir / "scripts"
+        if scripts_dir.is_dir():
+            helpers = sorted(
+                p.name
+                for p in scripts_dir.iterdir()
+                if p.is_file() and p.suffix in {".sh", ".py", ".md"}
+            )
+            for helper in helpers:
+                if helper not in readme:
+                    failures.append(
+                        f"scripts/{helper} exists but README.md never names it — document"
+                        " the helper (or remove it)"
+                    )
 
     # Check 6 — core word budget (ratchet; see module docstring).
     words = len(body.split())

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -127,6 +127,24 @@ check "skill-lint FAILS on bad name + oversize description" 1 "$rc"
 rc=0; python3 "$repo_root/scripts/skill-lint.py" "$scratch/does-not-exist/SKILL.md" >/dev/null 2>&1 || rc=$?
 check "skill-lint FAILS on a missing file" 1 "$rc"
 
+# Check 7 (README documentation integrity) — red/green both directions.
+docdir="$scratch/skill-fixture/doc-skill"
+mkdir -p "$docdir/references" "$docdir/scripts"
+printf -- '---\nname: doc-skill\ndescription: "A test skill."\n---\n# body\nRead references/covered.md.\n' > "$docdir/SKILL.md"
+printf '# covered\n' > "$docdir/references/covered.md"
+printf '#!/usr/bin/env bash\n' > "$docdir/scripts/mystery.sh"
+printf '# README\nNothing documented here.\n' > "$docdir/README.md"
+rc=0; python3 "$repo_root/scripts/skill-lint.py" "$docdir/SKILL.md" >/dev/null 2>&1 || rc=$?
+check "skill-lint FAILS when README omits a reference and a script helper" 1 "$rc"
+
+printf '# README\nCatalogue: covered.md. Helpers: mystery.sh.\n' > "$docdir/README.md"
+rc=0; python3 "$repo_root/scripts/skill-lint.py" "$docdir/SKILL.md" >/dev/null 2>&1 || rc=$?
+check "skill-lint PASSES when README names every reference and helper" 0 "$rc"
+
+# ...and a fixture with NO README (the good-skill shape) must stay exempt from check 7.
+rc=0; python3 "$repo_root/scripts/skill-lint.py" "$lintdir/SKILL.md" >/dev/null 2>&1 || rc=$?
+check "skill-lint remains PASS for a skill dir with no README (check 7 conditional)" 0 "$rc"
+
 # Block-scalar bypass (a Copilot-review catch): an oversize description written as a
 # multi-line block must still trip the length gate — the parser accumulates continuation
 # content instead of counting a sentinel.


### PR DESCRIPTION
## What changed
`scripts/skill-lint.py` check 7: when a README sits beside SKILL.md, every `references/*.md` on disk and every top-level `scripts/` helper (.sh/.py/.md) must be *named* in it — the deterministic form of the drift the audit found by hand (MED-5..7). Three new fixtures in `test-scripts.sh` (suite 37→40): fails on an omitted reference + helper, passes when named, no-README fixture shape stays exempt. The stale "core diet in flight" comment on `CORE_WORD_BUDGET` now cites ADR 0001 (PR #135) — ceiling, not target.

## Why
Audit LOW-11: findings 3–8 were deterministic checks nobody ran. Same move that turned the previous audit's LOW-6 into check 5 (reference integrity), which has held since. skill-lint is a required check, so this drift class now fails PRs instead of accumulating for the next audit.

## Testing
`test-scripts.sh` 40/40 (3 new red/green/exempt fixtures) · `skill-lint` PASS on the real tree (green *because* #134 fixed the drift — run against the pre-#134 tree this check fails exactly the audit's findings) · `shellcheck` clean · `leakage-guard` Tier 1+2 PASS.

## Review verdict
Self-review recorded: substring naming (not link parsing) keeps the check format-agnostic — the right trade for a drift tripwire; `scripts/tests/` deliberately excluded (the harness documents itself); no SKILL.md change → no eval obligation. Authored on Fable.