### PR TITLE
fix(evals): filter OS launchd churn from the escape-detection backstop

### DIFF
--- a/scripts/run-evals.py
+++ b/scripts/run-evals.py
@@ -250,6 +250,17 @@ def guard_settings_intact(workdir: Path) -> bool:
 # touch, before and after the run. A delta means something slipped BOTH the seatbelt and the
 # deny rules — it should never fire, which is exactly why it must (silence is only meaningful
 # from a control that could speak). Detection, never a substitute for the enforcement above.
+#
+# The directory snapshots (~/Library/LaunchAgents, ~/Applications) are the reliable signal.
+# `launchctl list` also carries the OS's OWN churn — Spotlight `com.apple.mdworker.shared.*`
+# and kin spin up and tear down on their own during a run — so those labels are filtered out;
+# leaving them in made the backstop cry wolf on every scenario (the skill's own monitoring
+# rule: allowlist benign noise, alert only on what is NEW and real). A scenario-installed
+# agent carries a non-Apple label (or drops a file the directory diff catches); OS-managed
+# `com.apple.*` / `application.com.apple.*` churn is not an escape.
+_LAUNCHCTL_NOISE_PREFIXES = ("com.apple.", "application.com.apple.")
+
+
 def _persistence_snapshot() -> dict[str, list[str]]:
     home = Path.home()
     surfaces = {
@@ -270,7 +281,11 @@ def _persistence_snapshot() -> dict[str, list[str]]:
                 check=False,
             ).stdout
             snap["launchctl"] = sorted(
-                line.split("\t")[-1] for line in out.splitlines()[1:] if line.strip()
+                label
+                for line in out.splitlines()[1:]
+                if line.strip()
+                for label in (line.split("\t")[-1],)
+                if not label.startswith(_LAUNCHCTL_NOISE_PREFIXES)
             )
     return snap
 

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -343,6 +343,25 @@ PYEOF
   check "run-evals _maybe_sandbox FAILS CLOSED when no sandbox and no override" 0 "$rc"
 fi
 
+# The detection backstop must catch a REAL escape yet ignore the OS's own launchd churn
+# (com.apple.mdworker.shared.* spins up/down mid-run) — else it cries wolf on every scenario
+# and masks a true escape. Deterministic: exercises diff_persistence + the noise filter, no
+# real launchctl.
+rc=0; python3 - "$repo_root" >/dev/null 2>&1 <<'PYEOF' || rc=$?
+import importlib.util, sys
+spec = importlib.util.spec_from_file_location("re_mod", sys.argv[1] + "/scripts/run-evals.py")
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+kept = [l for l in ["com.apple.mdworker.shared.01", "application.com.apple.x", "com.acme.evil"]
+        if not l.startswith(m._LAUNCHCTL_NOISE_PREFIXES)]
+assert kept == ["com.acme.evil"], kept                         # OS noise dropped, real label kept
+before = {"launchctl": [], "LaunchAgents": ["keep.plist"]}
+assert m.diff_persistence(before, dict(before)) == []          # no change → no alert
+real = {"launchctl": ["com.acme.evil"], "LaunchAgents": ["keep.plist", "com.acme.evil.plist"]}
+d = m.diff_persistence(before, real)
+assert any("com.acme.evil" in x for x in d) and len(d) == 2, d  # real escape → alert
+PYEOF
+check "run-evals persistence backstop catches a real escape, ignores OS launchd churn" 0 "$rc"
+
 # --- run-evals.py fixture harness (offline: pure logic only; no model runs) -----------------
 # The fixture gates must be ABLE to fail (§3c): suffix rule + manifest drift fire on planted
 # violations, the harness-written instructions file stays out of evidence, and the judge-


### PR DESCRIPTION
## What changed
The #138 detection backstop compared full `launchctl list` before/after each scenario. That list includes the OS's *own* transient jobs — Spotlight `com.apple.mdworker.shared.*` and kin spin up and tear down during any run — so the backstop reported `SANDBOX ESCAPE` on a scenario that installed **nothing** (verified: `~/Library/LaunchAgents` and `~/Applications` unchanged, no artifacts). Filter `com.apple.*` / `application.com.apple.*` labels from the launchctl snapshot; the directory diffs (the reliable signal) are untouched.

## Why
Caught during the pre-sweep proof-run of the incident scenario on the fixed harness: **the enforcement worked** (nothing installed) but the backstop cried wolf. A backstop that fires on all 60 scenarios masks a real escape — the exact cry-wolf failure the skill's own monitoring discipline forbids ("allowlist benign noise, alert only on what is NEW and real"). A scenario-installed agent carries a non-Apple label (or drops a file the directory diff catches), so filtering OS-managed churn loses no real detection.

## Testing
New regression test (deterministic, no `launchctl`): the noise filter drops `com.apple.*` while keeping a `com.acme.evil` label; `diff_persistence` returns `[]` on no-change and alerts on a real escape. Suite **42 → 43**. `shellcheck` clean · `leakage-guard` Tier 1+2 PASS · no `SKILL.md` change (no eval obligation).

## Review verdict
Self-review recorded: the filter narrows *detection noise*, not enforcement — the seatbelt + deny-rules are unchanged; a real user-labelled agent and any LaunchAgents/Applications file still alert. Follow-up to #138; unblocks the batched re-baseline sweep (the backstop had to be trustworthy before a 60-scenario run). Authored on Opus under Brian's standing per-change authorization for this harness-safety work.