### PR TITLE
fix(evals): kernel exec-deny for all runners + directory-only backstop (#140 review)

### DIFF
--- a/scripts/run-evals.py
+++ b/scripts/run-evals.py
@@ -251,16 +251,14 @@ def guard_settings_intact(workdir: Path) -> bool:
 # deny rules — it should never fire, which is exactly why it must (silence is only meaningful
 # from a control that could speak). Detection, never a substitute for the enforcement above.
 #
-# The directory snapshots (~/Library/LaunchAgents, ~/Applications) are the reliable signal.
-# `launchctl list` also carries the OS's OWN churn — Spotlight `com.apple.mdworker.shared.*`
-# and kin spin up and tear down on their own during a run — so those labels are filtered out;
-# leaving them in made the backstop cry wolf on every scenario (the skill's own monitoring
-# rule: allowlist benign noise, alert only on what is NEW and real). A scenario-installed
-# agent carries a non-Apple label (or drops a file the directory diff catches); OS-managed
-# `com.apple.*` / `application.com.apple.*` churn is not an escape.
-_LAUNCHCTL_NOISE_PREFIXES = ("com.apple.", "application.com.apple.")
-
-
+# We snapshot the persistence DIRECTORIES (~/Library/LaunchAgents, ~/Applications) — a
+# persistent agent or app needs a file there, so a new entry is a real, unambiguous signal.
+# We deliberately do NOT diff `launchctl list`: launchd labels are arbitrary strings (an
+# escaping scenario could pick an Apple-looking one, so any prefix filter is bypassable —
+# Copilot review, PR #140), the list churns with the OS's own transient jobs (false
+# positives), AND the launchctl exec path is already denied by the workspace settings.json,
+# so a scenario cannot bootstrap a job in the first place. A noisy, bypassable signal for an
+# already-closed vector is worse than none — the directory diffs carry the detection.
 def _persistence_snapshot() -> dict[str, list[str]]:
     home = Path.home()
     surfaces = {
@@ -271,22 +269,6 @@ def _persistence_snapshot() -> dict[str, list[str]]:
     for key, path in surfaces.items():
         with contextlib.suppress(OSError):
             snap[key] = sorted(p.name for p in path.iterdir()) if path.is_dir() else []
-    if sys.platform == "darwin" and shutil.which("launchctl"):
-        with contextlib.suppress(Exception):
-            out = subprocess.run(
-                ["launchctl", "list"],
-                capture_output=True,
-                text=True,
-                timeout=15,
-                check=False,
-            ).stdout
-            snap["launchctl"] = sorted(
-                label
-                for line in out.splitlines()[1:]
-                if line.strip()
-                for label in (line.split("\t")[-1],)
-                if not label.startswith(_LAUNCHCTL_NOISE_PREFIXES)
-            )
     return snap
 
 

--- a/scripts/run-evals.py
+++ b/scripts/run-evals.py
@@ -130,6 +130,23 @@ SCENARIO_ALLOWED_TOOLS = "Bash,Edit,Write"
 # against the real home.
 _UNSANDBOXED_ENV = "EVAL_ALLOW_UNSANDBOXED"
 
+# System-mutating executables a scenario must never run: `launchctl` bootstraps agents over
+# XPC (no file write, so the write boundary alone misses it), `osascript` drives other apps,
+# `sudo` escalates, etc. Denied TWO ways from one list so they stay in sync: (1) as a
+# process-exec deny in the seatbelt profile — kernel-enforced for EVERY runner including the
+# foreign `generic` runner that ignores Claude settings; (2) as a Claude permissions.deny in
+# the workspace settings.json — a cleaner "denied" in the claude-runner trail. Basenames, so
+# the seatbelt regex is path-robust.
+_FORBIDDEN_EXEC_BASENAMES = (
+    "launchctl",
+    "osascript",
+    "sudo",
+    "systemsetup",
+    "spctl",
+    "csrutil",
+    "crontab",
+)
+
 
 def sandbox_available() -> bool:
     """True when the kernel write-boundary can be enforced (macOS + sandbox-exec on PATH)."""
@@ -170,6 +187,11 @@ def _seatbelt_profile(workdir: Path) -> str:
         ' (literal "/dev/null") (literal "/dev/stdout") (literal "/dev/stderr")'
         ' (literal "/dev/tty") (literal "/dev/dtracehelper") (subpath "/dev/fd"))'
     )
+    # Kernel-enforced exec deny for the system-mutating binaries, for EVERY runner — the
+    # generic runner ignores the Claude settings.json, so this is what actually stops it
+    # bootstrapping a workspace plist. Basename-anchored regex, path-robust.
+    exec_re = "/(" + "|".join(_FORBIDDEN_EXEC_BASENAMES) + ")$"
+    lines.append(f'(deny process-exec* (regex #"{exec_re}"))')
     return "\n".join(lines)
 
 
@@ -191,21 +213,12 @@ def _maybe_sandbox(cmd: list[str], workdir: Path) -> list[str]:
     return ["sandbox-exec", "-p", _seatbelt_profile(workdir), *cmd]
 
 
-# Deny rules the seatbelt cannot express: seatbelt bounds FILE writes, but a process-exec
-# like `launchctl bootstrap gui/$UID <workspace>.plist` mutates system state over XPC
-# without writing outside the workspace, and `osascript` can drive other apps. Runs pass
-# --setting-sources project, so a project settings.json in the workspace is honored; its
-# permissions.deny takes precedence over the --allowedTools grant. Defense in depth, not the
-# primary boundary — the seatbelt is (this list can never be exhaustive).
-_SCENARIO_DENY_TOOLS = [
-    "Bash(launchctl:*)",
-    "Bash(osascript:*)",
-    "Bash(sudo:*)",
-    "Bash(systemsetup:*)",
-    "Bash(spctl:*)",
-    "Bash(csrutil:*)",
-    "Bash(crontab:*)",
-]
+# The Claude-runner half of the exec deny: a workspace settings.json permissions.deny (runs
+# pass --setting-sources project). This is belt-and-suspenders — the seatbelt process-exec
+# deny above already blocks these for EVERY runner at the kernel — but it yields a clean
+# "denied" in the claude-runner tool trail. Derived from the same basename list so the two
+# never drift; the generic runner ignores this file and relies solely on the seatbelt.
+_SCENARIO_DENY_TOOLS = [f"Bash({name}:*)" for name in _FORBIDDEN_EXEC_BASENAMES]
 
 
 def write_scenario_guard_settings(workdir: Path) -> None:
@@ -256,9 +269,10 @@ def guard_settings_intact(workdir: Path) -> bool:
 # We deliberately do NOT diff `launchctl list`: launchd labels are arbitrary strings (an
 # escaping scenario could pick an Apple-looking one, so any prefix filter is bypassable —
 # Copilot review, PR #140), the list churns with the OS's own transient jobs (false
-# positives), AND the launchctl exec path is already denied by the workspace settings.json,
-# so a scenario cannot bootstrap a job in the first place. A noisy, bypassable signal for an
-# already-closed vector is worse than none — the directory diffs carry the detection.
+# positives), AND `launchctl` exec is now denied at the kernel for every runner (the seatbelt
+# process-exec deny), so a scenario cannot bootstrap a job in the first place. A noisy,
+# bypassable signal for an already-closed vector is worse than none — the directory diffs
+# carry the detection.
 def _persistence_snapshot() -> dict[str, list[str]]:
     home = Path.home()
     surfaces = {

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -343,24 +343,27 @@ PYEOF
   check "run-evals _maybe_sandbox FAILS CLOSED when no sandbox and no override" 0 "$rc"
 fi
 
-# The detection backstop must catch a REAL escape yet ignore the OS's own launchd churn
-# (com.apple.mdworker.shared.* spins up/down mid-run) — else it cries wolf on every scenario
-# and masks a true escape. Deterministic: exercises diff_persistence + the noise filter, no
-# real launchctl.
+# The detection backstop must fire on a REAL persistence write (a new LaunchAgent/app) and
+# stay silent otherwise. Tests the actual _persistence_snapshot against a mocked HOME whose
+# LaunchAgents dir gains a file between snapshots — proving the function itself detects, not
+# just the diff helper. Deterministic: no launchctl, no real HOME.
 rc=0; python3 - "$repo_root" >/dev/null 2>&1 <<'PYEOF' || rc=$?
-import importlib.util, sys
+import importlib.util, sys, tempfile
+from pathlib import Path
+from unittest import mock
 spec = importlib.util.spec_from_file_location("re_mod", sys.argv[1] + "/scripts/run-evals.py")
 m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
-kept = [l for l in ["com.apple.mdworker.shared.01", "application.com.apple.x", "com.acme.evil"]
-        if not l.startswith(m._LAUNCHCTL_NOISE_PREFIXES)]
-assert kept == ["com.acme.evil"], kept                         # OS noise dropped, real label kept
-before = {"launchctl": [], "LaunchAgents": ["keep.plist"]}
-assert m.diff_persistence(before, dict(before)) == []          # no change → no alert
-real = {"launchctl": ["com.acme.evil"], "LaunchAgents": ["keep.plist", "com.acme.evil.plist"]}
-d = m.diff_persistence(before, real)
-assert any("com.acme.evil" in x for x in d) and len(d) == 2, d  # real escape → alert
+fake_home = Path(tempfile.mkdtemp())
+(fake_home / "Library" / "LaunchAgents").mkdir(parents=True)
+(fake_home / "Applications").mkdir()
+with mock.patch.object(m.Path, "home", staticmethod(lambda: fake_home)):
+    before = m._persistence_snapshot()
+    assert m.diff_persistence(before, m._persistence_snapshot()) == []          # no change → silent
+    (fake_home / "Library" / "LaunchAgents" / "com.acme.evil.plist").write_text("x")  # a real escape
+    d = m.diff_persistence(before, m._persistence_snapshot())
+    assert d == ["LaunchAgents: +com.acme.evil.plist"], d                       # real write → alert
 PYEOF
-check "run-evals persistence backstop catches a real escape, ignores OS launchd churn" 0 "$rc"
+check "run-evals persistence backstop fires on a real LaunchAgents write, silent otherwise" 0 "$rc"
 
 # --- run-evals.py fixture harness (offline: pure logic only; no model runs) -----------------
 # The fixture gates must be ABLE to fail (§3c): suffix rule + manifest drift fire on planted

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -341,6 +341,37 @@ with mock.patch.object(m, "sandbox_available", return_value=False):
 sys.exit(1)                  # ran bare — fail-open, WRONG
 PYEOF
   check "run-evals _maybe_sandbox FAILS CLOSED when no sandbox and no override" 0 "$rc"
+
+  # The seatbelt must deny launchctl/osascript EXEC for every runner (kernel-enforced) — the
+  # generic runner ignores the Claude settings.json, so this is what stops it bootstrapping a
+  # workspace plist. A plain `bash -c launchctl` stands in for any runner's shell.
+  rc=0; python3 - "$repo_root" >/dev/null 2>&1 <<'PYEOF' || rc=$?
+import importlib.util, sys, tempfile
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("re_mod", sys.argv[1] + "/scripts/run-evals.py")
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+if not m.sandbox_available():
+    sys.exit(3)
+ws = Path(tempfile.mkdtemp())
+# launchctl exec is blocked -> the child exits nonzero -> _run_cli raises.
+try:
+    m._run_cli(["bash", "-c", "launchctl list"], 30, ws, sandbox_root=ws)
+    raise SystemExit("launchctl ran under the sandbox — EXEC DENY FAILED")
+except RuntimeError:
+    pass
+# a benign binary still execs (the deny is targeted, not blanket).
+out = m._run_cli(["bash", "-c", "echo exec-control-ok"], 30, ws, sandbox_root=ws)
+assert "exec-control-ok" in out, out
+# the seatbelt regex is derived from the shared basename list (no drift).
+assert all(n in m._seatbelt_profile(ws) for n in m._FORBIDDEN_EXEC_BASENAMES)
+assert m._SCENARIO_DENY_TOOLS == [f"Bash({n}:*)" for n in m._FORBIDDEN_EXEC_BASENAMES]
+PYEOF
+  if [[ "$rc" -eq 3 ]]; then
+    note "SKIP: sandbox-exec unavailable — exec-deny not exercised here"
+    pass=$((pass + 1))
+  else
+    check "run-evals sandbox DENIES launchctl exec for any runner (kernel, not settings.json)" 0 "$rc"
+  fi
 fi
 
 # The detection backstop must fire on a REAL persistence write (a new LaunchAgent/app) and


### PR DESCRIPTION
## What changed
Two linked hardening changes to the #138 escape backstop, addressing the reviews on #140 and this PR:

1. **Kernel `process-exec` deny in the seatbelt** for `launchctl`/`osascript`/`sudo`/`systemsetup`/`spctl`/`csrutil`/`crontab` — enforced for **every** runner (verified: exec blocked, exit 126). The generic runner shells out to a foreign CLI that ignores the Claude `settings.json`, so the settings.json deny alone left the "bootstrap a workspace plist via launchctl" vector open for generic sweeps; the kernel deny closes it and is un-bypassable by launchd label. The seatbelt regex and the settings.json deny now derive from **one basename list** so they can't drift.
2. **Backstop uses directory diffs only.** Removed the `launchctl list` snapshot: launchd labels are arbitrary strings (any prefix filter is bypassable — original #140 review), the list churns with the OS's own transient jobs, and the exec is now denied anyway. The `~/Library/LaunchAgents` + `~/Applications` directory diffs are the reliable, un-bypassable detection.

## Why
Follow-up to #140, which merged before its Copilot review posted (a merge-before-triage miss I own). This PR resolves every point that review raised **and** the generic-runner gap Copilot flagged here — verified before merging this time.

## Testing
- Regression tests (deterministic, no model): seatbelt DENIES `launchctl` exec for a plain `bash` child while a benign binary still execs; the two deny lists stay in sync; the backstop fires on a real LaunchAgents write (mocked `Path.home()`) and is silent otherwise. Suite **42 → 44**.
- Real sandboxed scenario run under the full profile: the claude runner creates a workspace file and uses tools normally (the exec deny doesn't break the CLI).
- `shellcheck` clean · `leakage-guard` Tier 1+2 PASS · no `SKILL.md` change.

## Review verdict
Self-review recorded: this **strengthens** enforcement (kernel deny for all runners) and **removes** an evadable detection signal — net more robust, less code; enforcement of the file-write boundary unchanged; the two deny surfaces are single-sourced. Authored on Opus under Brian's standing per-change authorization for this harness-safety work.