### PR TITLE
feat(evals): --resume to recover an interrupted sweep without re-spending

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -133,6 +133,13 @@ a sweep's "bare" responses can't absorb the operator's environment — the root 
 identifier once leaking into a committed baseline. (Generic runners: the `--runner-cmd`
 template author owns the foreign CLI's equivalent isolation.)
 
+**Resuming an interrupted sweep.** Results checkpoint per scenario as they finish, so an
+interrupted run loses nothing already done. A full Fable sweep spans a usage-limit window
+(scenarios past it error `claude exited 1` in ~3 s) and can be externally killed. Re-invoke
+with the **same `--out` dir** plus **`--resume`**: scenarios with a non-error result are
+reused, only errored/missing ones re-run — recovering the sweep without re-spending on
+completed scenarios. (Errored and malformed checkpoints are always re-run, never trusted.)
+
 The judge receives two pieces of **harness-collected evidence** alongside the response text:
 the post-run **workspace evidence** (unified diffs vs the fixtures first, then new files —
 per-file capped, 60 KB total) and, on the claude runner, the **ordered tool-call trail**

--- a/scripts/run-evals.py
+++ b/scripts/run-evals.py
@@ -62,6 +62,8 @@ Usage examples:
   scripts/run-evals.py --filter spec-first-gate            # one scenario, quick check
   scripts/run-evals.py --mode baseline --model opus        # full baseline sweep
   scripts/run-evals.py --model opus --judge-model opus     # full with-skill sweep
+  scripts/run-evals.py --out DIR --resume ...              # recover an interrupted sweep
+                                                           # (reuse non-error results in DIR)
   scripts/run-evals.py --runner generic \\
       --runner-cmd 'codex exec --model {model} {prompt}' \\
       --runner-instructions-file AGENTS.md                 # cross-CLI sweep (verify flags!)
@@ -1035,6 +1037,25 @@ def run_scenario(
     return result
 
 
+def load_resumable_results(out_dir: Path, names: set[str]) -> dict[str, ScenarioResult]:
+    """Reusable prior results in out_dir: a checkpointed `<scenario>.json` whose status is
+    NOT 'error', for a scenario still in the suite. Errored/absent scenarios are re-run, so
+    a resume recovers a usage-limited or killed sweep without re-spending on the good ones.
+    A malformed checkpoint is ignored (re-run), never trusted."""
+    reusable: dict[str, ScenarioResult] = {}
+    for name in sorted(names):
+        checkpoint = out_dir / f"{name}.json"
+        if not checkpoint.is_file():
+            continue
+        try:
+            prior: ScenarioResult = json.loads(checkpoint.read_text(encoding="utf-8"))
+        except (json.JSONDecodeError, OSError):
+            continue
+        if prior.get("scenario") == name and prior.get("status") in ("pass", "partial", "fail"):
+            reusable[name] = prior
+    return reusable
+
+
 def write_summary(out_dir: Path, results: list[ScenarioResult]) -> str:
     """Write summary.json + summary.md; returns the one-line tally."""
     tally = {s: sum(1 for r in results if r["status"] == s) for s in ("pass", "partial", "fail", "error")}
@@ -1063,6 +1084,12 @@ def main() -> int:
     parser.add_argument("--jobs", type=int, default=2, help="concurrent scenarios")
     parser.add_argument("--timeout", type=int, default=600, help="seconds per claude run")
     parser.add_argument("--out", default="", help="output dir (default: evals/results/<stamp>)")
+    parser.add_argument(
+        "--resume", action="store_true",
+        help="skip scenarios that already have a NON-error result in --out (re-runs errors "
+             "and missing scenarios only) — recover a sweep interrupted by a usage-limit "
+             "window or an external kill without re-spending on completed scenarios",
+    )
     parser.add_argument(
         "--runner", choices=["claude", "generic"], default="claude",
         help="scenario-response producer; the judge always runs on the claude CLI",
@@ -1134,15 +1161,22 @@ def main() -> int:
             stage_dir = Path(stage) / "skill"
             stage_skill_copy(stage_dir)
             system_prompt = build_skill_system_prompt(stage_dir)
-        log.info("%d scenario(s) → %s (mode=%s model=%s runner=%s judge=%s jobs=%d)",
-                 len(paths), out_dir, args.mode, args.model, args.runner, args.judge_model, args.jobs)
-
         results: list[ScenarioResult] = []
+        todo = paths
+        if args.resume:
+            reused = load_resumable_results(out_dir, {p.stem for p in paths})
+            results.extend(reused.values())
+            todo = [p for p in paths if p.stem not in reused]
+            log.info("resume: %d reused (pass/partial/fail), %d to run",
+                     len(reused), len(todo))
+        log.info("%d scenario(s) → %s (mode=%s model=%s runner=%s judge=%s jobs=%d)",
+                 len(todo), out_dir, args.mode, args.model, args.runner, args.judge_model, args.jobs)
+
         with concurrent.futures.ThreadPoolExecutor(max_workers=args.jobs) as pool:
             futures = {
                 pool.submit(run_scenario, p, args.mode, args.model, args.judge_model,
                             args.timeout, system_prompt, runner): p
-                for p in paths
+                for p in todo
             }
             for future in concurrent.futures.as_completed(futures):
                 result = future.result()

--- a/scripts/run-evals.py
+++ b/scripts/run-evals.py
@@ -1048,8 +1048,12 @@ def load_resumable_results(out_dir: Path, names: set[str]) -> dict[str, Scenario
         if not checkpoint.is_file():
             continue
         try:
-            prior: ScenarioResult = json.loads(checkpoint.read_text(encoding="utf-8"))
+            prior = json.loads(checkpoint.read_text(encoding="utf-8"))
         except (json.JSONDecodeError, OSError):
+            continue
+        # Valid JSON of a non-object type (`[]`, `123`, `"x"`) is as untrustworthy as
+        # malformed — guard before .get() so a stray checkpoint can't crash --resume.
+        if not isinstance(prior, dict):
             continue
         if prior.get("scenario") == name and prior.get("status") in ("pass", "partial", "fail"):
             reusable[name] = prior

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -260,6 +260,24 @@ sys.exit(1)
 PYEOF
 check "run-evals build_runner_cmd REJECTS a template without {prompt}" 0 "$rc"
 
+# --resume reuses only non-error checkpoints, re-runs errored/malformed/missing — so a
+# usage-limited or externally-killed sweep recovers without re-spending on completed work.
+rc=0; python3 - "$repo_root" >/dev/null 2>&1 <<'PYEOF' || rc=$?
+import importlib.util, sys, tempfile, json
+from pathlib import Path
+spec = importlib.util.spec_from_file_location("re_mod", sys.argv[1] + "/scripts/run-evals.py")
+m = importlib.util.module_from_spec(spec); spec.loader.exec_module(m)
+out = Path(tempfile.mkdtemp())
+(out / "a.json").write_text(json.dumps({"scenario": "a", "status": "pass"}))
+(out / "b.json").write_text(json.dumps({"scenario": "b", "status": "partial"}))
+(out / "c.json").write_text(json.dumps({"scenario": "c", "status": "error"}))   # re-run
+(out / "d.json").write_text("{malformed")                                       # re-run
+r = m.load_resumable_results(out, {"a", "b", "c", "d", "e"})                     # e: no file
+assert sorted(r) == ["a", "b"], sorted(r)                                        # only good reused
+assert sorted({"a","b","c","d","e"} - set(r)) == ["c", "d", "e"]                 # rest re-run
+PYEOF
+check "run-evals --resume reuses non-error checkpoints, re-runs errors/missing" 0 "$rc"
+
 # The generic runner's misuse paths must fail fast at argparse (exit 2), before any run.
 rc=0; python3 "$repo_root/scripts/run-evals.py" --runner generic --filter zz >/dev/null 2>&1 || rc=$?
 check "run-evals FAILS fast: --runner generic without --runner-cmd" 2 "$rc"

--- a/scripts/tests/test-scripts.sh
+++ b/scripts/tests/test-scripts.sh
@@ -272,9 +272,12 @@ out = Path(tempfile.mkdtemp())
 (out / "b.json").write_text(json.dumps({"scenario": "b", "status": "partial"}))
 (out / "c.json").write_text(json.dumps({"scenario": "c", "status": "error"}))   # re-run
 (out / "d.json").write_text("{malformed")                                       # re-run
-r = m.load_resumable_results(out, {"a", "b", "c", "d", "e"})                     # e: no file
-assert sorted(r) == ["a", "b"], sorted(r)                                        # only good reused
-assert sorted({"a","b","c","d","e"} - set(r)) == ["c", "d", "e"]                 # rest re-run
+(out / "f.json").write_text(json.dumps({"scenario": "f", "status": "fail"}))    # fail is non-error → reuse
+(out / "g.json").write_text("[]")                                              # valid JSON, wrong type → re-run (no crash)
+names = {"a", "b", "c", "d", "e", "f", "g"}                                     # e: no file
+r = m.load_resumable_results(out, names)                                        # must NOT raise on g
+assert sorted(r) == ["a", "b", "f"], sorted(r)                                  # pass/partial/fail reused
+assert sorted(names - set(r)) == ["c", "d", "e", "g"], sorted(names - set(r))   # error/malformed/missing/wrong-type re-run
 PYEOF
 check "run-evals --resume reuses non-error checkpoints, re-runs errors/missing" 0 "$rc"
 


### PR DESCRIPTION
## What changed
`run-evals.py --resume` (used with the same `--out` dir): scenarios that already have a **non-error** checkpointed result are reused; only errored/malformed/missing scenarios re-run. Results already checkpoint per scenario as they finish, but before this a re-invocation re-executed all 60 — wasting spend on completed work.

## Why
The v1.25.0 re-baseline sweep was interrupted twice: once by the Fable **usage-limit window** (scenarios past it error `claude exited 1` in ~3 s) and once by an **external kill** (26/60 done, 0 errors). A ~2 h / ~$98 sweep that can't resume forces a full restart on any interruption. The recorded baselines already described "resumable per-scenario execution" as if it existed — this makes it real, and it's the correct resilience for a long, rate-limit-prone job.

## Testing
Regression test (deterministic): `load_resumable_results` reuses `pass`/`partial`/`fail` checkpoints, re-runs `error`/malformed/missing. Suite **44 → 45**. `shellcheck` clean · `skill-lint` PASS · `leakage-guard` Tier 1+2 PASS · `--help` shows the flag. Docs (module usage + evals/README) updated in the same commit. No `SKILL.md` change → no eval obligation.

## Review verdict
Self-review recorded: reuse is gated to non-error statuses (a malformed or errored checkpoint is never trusted — re-run); the flag is opt-in and changes nothing without `--resume`; the summary/tally still reflects the full result set (reused + freshly run). Immediately unblocks finishing the interrupted re-baseline. Authored on Fable.