### PR TITLE
fix(evals): establish the existing mypy ratchet in the gate-promotion-ladder scenario

### DIFF
--- a/evals/scenarios/gate-promotion-ladder.json
+++ b/evals/scenarios/gate-promotion-ladder.json
@@ -2,7 +2,7 @@
   "skills": [
     "senior-engineering-partner"
   ],
-  "query": "We want to add semgrep and a duplication check to our 5-year-old 300k-line Django monolith's CI. Last time we tried adding a linter it flagged 4,000 legacy issues, blocked every open PR, and got reverted in two days. How should we roll these out? Also our security lead wants gitleaks added the same way, eased in gently.",
+  "query": "We want to add semgrep and a duplication check to our 5-year-old 300k-line Django monolith's CI. Last time we tried adding a linter it flagged 4,000 legacy issues, blocked every open PR, and got reverted in two days. (The one gate that DID stick was mypy --strict, which we only run on touched modules and widen over time.) How should we roll these out? Also our security lead wants gitleaks added the same way, eased in gently.",
   "files": [],
   "expected_behavior": [
     "Proposes the graduated monitor -> comment -> block introduction for the QUALITY gates, with the promotion trigger written down when the gate is added",


### PR DESCRIPTION
## What changed
One sentence added to the scenario query: the codebase now states its one sticky gate is `mypy --strict` run on touched modules and widened over time. Criterion [3] is **unchanged**.

## Why it changed
Criterion [3] asks the model to connect diff-scoping to *'the **existing** mypy ratchet pattern'* — but the scenario world contained no mypy (`files: []`, query never mentions it). It presupposed context that didn't exist, demanding an unprompted cross-tool tangent instead of testing **reuse-before-you-write**. With the ratchet established in-world, the criterion tests what its wording always intended: connect to the existing mechanism rather than inventing a new one.

## Evidence (3× runs each, fable scenario / opus judge)
| State | Criterion [3] |
|---|---|
| pre #144 | fail / fail / fail |
| post #144 (trigger sharpening) | fail / pass / fail |
| post this amendment | **pass / pass / pass** |

Run 1 post-amendment is the scenario's first clean overall **pass**; anti-behaviors clean in all runs. Remaining wobble is criterion [4] only (pass/unclear/fail — bidirectional judge variance in every baseline, not a gap).

## Testing instructions
- `python3 scripts/skill-lint.py` / `./scripts/leakage-guard.sh` / `./scripts/tests/test-scripts.sh` — all PASS (45/45)
- Re-run: `python3 scripts/run-evals.py --mode with-skill --model fable --filter gate-promotion-ladder`

Consent-gated loop: eval sharpening (add/sharpen only — the criterion is not relaxed); SKILL.md untouched.