### PR TITLE
docs: index the 2026-08-10 baseline as current; record the release-please merge-to-tag race

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -79,6 +79,17 @@ lands) and prepends the new section to
    *(Learned the hard way: the 1.5.0 release PR stayed `autorelease: pending` and silently blocked the
    1.6.0 release PR across six green workflow runs until it was relabeled.)*
 
+> **Expect a bogus release PR in the merge-to-tag window — close it, don't merge it.**
+> release-please runs on the push to `main` that the release merge itself creates — i.e.
+> *before* a human can finish steps 3–4. In that window the just-merged release PR is
+> still `autorelease: pending` and the new tag doesn't exist, so release-please has no
+> version baseline and re-derives one from the **entire commit history** — the v1.26.0
+> cut produced a "release 1.11.0" PR 35 seconds after the merge, collecting every
+> feature back to the repo's origin. Once steps 3–4 are done, close the misfire and
+> **remove its `autorelease: pending` label** (a pending label on the closed PR can
+> confuse later runs). Verify on the next real merge that release-please derives the
+> correct next version; a wrong version *outside* this window is a real bug, not the race.
+
 ### Gotcha (historical here since the title-only flip; live wherever squash includes the PR body): a squash body can make release-please skip the commit entirely
 
 **Since 2026-07-02 this repo squashes with "Default to pull request title" only** (API:

--- a/evals/README.md
+++ b/evals/README.md
@@ -1,6 +1,6 @@
 # Evals for senior-engineering-partner
 
-Last updated: 2026-07-28 07:48 AM CDT
+Last updated: 2026-08-13 11:24 PM CDT
 
 A regression suite for the skill itself. Each scenario encodes a **real miss** the skill exists to
 prevent — most are drawn straight from the SKILL.md changelog — so the suite is the executable form of
@@ -233,8 +233,15 @@ judge reasons, with the response transcripts stripped — plus a `BASELINE.md` s
 headline numbers, the per-scenario gap table, and the harness caveats. Record one **before
 any large core edit** and validate the edit by re-running **both** modes under the same
 harness afterward; a baseline only covers the scenarios that existed when it was taken
-(added/edited scenarios re-baseline on the next sweep). **Current (harness v2, 56-scenario
-suite, recorded 2026-07-27/28):**
+(added/edited scenarios re-baseline on the next sweep). **Current (sandboxed harness v3,
+recorded 2026-08-10, amended 2026-08-14):**
+[`baselines/2026-08-10-fable/`](baselines/2026-08-10-fable/BASELINE.md) — with-skill
+**36/25/0/0 on 61 scenarios**, zero fails and zero sandbox escape; the first baseline on
+the sandboxed harness and the record that closed the four v1.25.0 `Eval-waiver`s (bare
+reference remains the 2026-07-28 run — same model, no bare re-sweep). The 2026-08-14
+amendment appended `launchd-descriptive-executable-name` (pass) per the coverage
+tripwire; details and the multi-cycle-assembly caveat in its `BASELINE.md`.
+**Prior (harness v2, 56-scenario suite, recorded 2026-07-27/28):**
 [`baselines/2026-07-27-opus/`](baselines/2026-07-27-opus/BASELINE.md) — bare 15/28/13/0 vs
 with-skill **42/13/1/0**;
 [`baselines/2026-07-28-fable/`](baselines/2026-07-28-fable/BASELINE.md) — bare 9/30/17/0 vs


### PR DESCRIPTION
Two gaps a docs-currency sweep found after v1.26.0:
- evals/README's Recorded baselines still named the 2026-07-27/28 records
  as current; the 2026-08-10-fable baseline (61 scenarios, 36/25/0/0,
  zero escape, closed the four v1.25.0 waivers) now leads the index.
- MAINTAINERS' release runbook now documents the merge-to-tag window race
  (release-please fires on the release merge's own push and derives a
  bogus version from full history - the v1.26.0 cut produced a '1.11.0'
  PR 35s after merge) and the close-and-strip-label remedy.
