### PR TITLE
feat(deps): lockstep pairs — exact-version-pinned siblings bump as one Dependabot group

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -175,10 +175,10 @@ Run or prescribe security tooling in every deliverable — never wait to be aske
 - **General:** check for exposed secrets (`git-secrets` or equivalent) before any commit guidance.
 
 ## GitHub security alerts & Dependabot (ENFORCED — keep the alert tab at zero)
-Every GitHub repo gets supply-chain alerting *turned on and acted on* — advisories are work items, not a dashboard. (Other hosts: GitLab dependency scanning + secret detection, else Renovate + gitleaks in CI — alerting on, count zero.)
+Every GitHub repo gets supply-chain alerting *turned on and acted on* — advisories are work items, not a dashboard. (Other hosts: GitLab dependency scanning + secret detection, else Renovate + gitleaks in CI.)
 - **Enable the trio**: Dependabot **alerts**, **security updates**, and **secret scanning + push protection**. Commit `.github/dependabot.yml` covering *every* ecosystem (`pip`, `npm`, `github-actions`, `docker`, …) so SHA-pinned actions and digest-pinned images don't fall behind.
-- **Triage every alert; zero open.** Bump the pin (and any drifted manifest — below), or dismiss a false positive/unreachable path *with a written reason*. An ignored alert tab is an unowned, growing liability.
-- **Review Dependabot's PRs as code** — CI gates them, read the changelog for breaking changes, then merge. No blind auto-merge; no rot.
+- **Triage every alert; zero open.** Bump the pin (and any drifted manifest — below), or dismiss a false positive/unreachable path *with a written reason*.
+- **Review Dependabot's PRs as code** — CI gates them, read the changelog for breaking changes, then merge. No blind auto-merge; no rot. **Lockstep pairs bump together:** exact-version-pinned siblings (`vitest`/`@vitest/coverage-v8`) never merge singly — one `groups` entry per pair (`references/package-managers.md`).
 - **Scanners are necessary but NOT sufficient — know each one's blind spots.** An image/OS scanner (Trivy/grype) sees only built-image packages, usually floored at HIGH/CRITICAL — it misses (1) **MEDIUM/LOW advisories** (still real on a hostile-input path, e.g. a PDF/zip parser), (2) a **manifest in no image** (legacy/dev-only requirements), (3) **manifest drift** (`pyproject.toml` behind `requirements.txt`). Gate the *manifests themselves* (below); never present "image scan green" as "no known vulns."
 
 ## Dependency-audit gate (manifest-level, all severities) — REQUIRED where deps are pinned
@@ -424,7 +424,7 @@ A second writer — agent or human — in the tree overrides the solo-speed Defi
 | **Website** | https://briangreenberg.net |
 | **License** | Apache-2.0 |
 | **Created** | 2026-05-18 |
-| **Last updated** | 2026-08-13 |
+| **Last updated** | 2026-09-05 |
 | **Version** | 1.26.0 | <!-- x-release-please-version -->
 
 ### Changelog

--- a/evals/baselines/2026-08-10-fable/BASELINE.md
+++ b/evals/baselines/2026-08-10-fable/BASELINE.md
@@ -83,3 +83,12 @@ anti-behaviors clean, $1.04 / 64 s. Headline is now **36 pass / 25 partial / 0 f
 entry is from a different sitting than the other 60. (The 2026-08-14 scenario amendment
 to `gate-promotion-ladder` (#145) post-dates the recorded result for that scenario; its
 3× post-amendment evidence lives in PR #145.)
+
+## Amendment 2026-09-05 — `dependabot-lockstep-pair` appended (62nd scenario)
+
+The lockstep-pairs rule (exact-version-pinned siblings bump as one Dependabot `groups`
+PR) shipped with its guarding scenario after this baseline; the coverage tripwire refused
+the merge until the scenario was baselined. Appended from a single clean 2026-09-05 run
+(same harness, `fable` scenario / `opus` judge, sandboxed): **pass**, 5/5 criteria, all 3
+anti-behaviors clean, $1.33 / 42 s. Headline is now **37 pass / 25 partial / 0 fail /
+0 error on 62 scenarios**. Same different-sitting caveat as the 2026-08-14 amendment.

--- a/evals/baselines/2026-08-10-fable/with-skill.json
+++ b/evals/baselines/2026-08-10-fable/with-skill.json
@@ -1,6 +1,6 @@
 {
   "tally": {
-    "pass": 36,
+    "pass": 37,
     "partial": 25,
     "fail": 0,
     "error": 0
@@ -905,6 +905,61 @@
       "judge_reason": "The delivered code implements explicit timeouts, capped jittered backoff on transient-only failures, a labeled degraded 200 path, and loud structured logging, but never addresses bulkhead isolation or a circuit breaker for a chronically failing provider.",
       "cost_usd": 3.154901,
       "duration_s": 309.5
+    },
+    {
+      "scenario": "dependabot-lockstep-pair",
+      "mode": "with-skill",
+      "model": "fable",
+      "runner": "claude",
+      "judge_model": "opus",
+      "status": "pass",
+      "expected": [
+        {
+          "behavior": "Identifies this as a lockstep pair: @vitest/coverage-v8 is pinned to the exact vitest version, so a single-package bump can never install \u2014 the PR is not flaky and not a breaking change",
+          "verdict": "pass",
+          "evidence": "\"`vitest` and `@vitest/coverage-v8` are a lockstep pair. The coverage package declares an exact peer dependency... A PR that bumps only one member can never install cleanly\"; explains the three reopenings as root-cause, not flakiness"
+        },
+        {
+          "behavior": "Prescribes the pair-bump: vitest AND @vitest/coverage-v8 to the same version in ONE commit/PR, with npm ci kept strict",
+          "verdict": "pass",
+          "evidence": "\"Bump both members in one commit, exact-pinned\" with `npm install vitest@4.0.1 @vitest/coverage-v8@4.0.1 --save-exact` then `npm ci && npm test`; no flag added to CI install"
+        },
+        {
+          "behavior": "Prescribes a Dependabot `groups` entry (patterns vitest + @vitest/*), or the Renovate groupName equivalent, so the family is bumped as one PR from now on \u2014 added in the same PR as the fix",
+          "verdict": "pass",
+          "evidence": "\"In the same PR, add a `groups` entry to `.github/dependabot.yml`\" with patterns [\"vitest\", \"@vitest/*\"]"
+        },
+        {
+          "behavior": "Says the single-member Dependabot PR is closed (superseded), not coerced green",
+          "verdict": "pass",
+          "evidence": "\"Close the Dependabot PR with a comment saying it is a lockstep pair and will be bumped together.\""
+        },
+        {
+          "behavior": "Names why the coercions are wrong: --legacy-peer-deps / --force / an overrides pin ship the mismatched pair the tool's own check exists to refuse",
+          "verdict": "pass",
+          "evidence": "\"You would ship vitest 3.2.4 with a 4.0.1 coverage provider, which is exactly the mismatch the peer check exists to refuse... The same applies to `--force` and to an `overrides` pin.\""
+        }
+      ],
+      "anti": [
+        {
+          "behavior": "Recommends --legacy-peer-deps, --force, or an overrides/resolutions pin to make the lone bump install",
+          "verdict": "clean",
+          "evidence": "Opens with \"No. Do not add `--legacy-peer-deps`.\" and rejects --force/overrides too"
+        },
+        {
+          "behavior": "Treats the repeated re-opening as flakiness to retry, or advises auto-merge / ignoring the PR",
+          "verdict": "clean",
+          "evidence": "Reopenings attributed to structural root cause; PR is closed as superseded with an explanatory comment, not ignored or auto-merged"
+        },
+        {
+          "behavior": "Bumps only one member of the pair",
+          "verdict": "clean",
+          "evidence": "Both members bumped to 4.0.1 in one command/commit"
+        }
+      ],
+      "judge_reason": "The response correctly diagnoses the lockstep pair, refuses the coercion flags with reasons, prescribes a same-version pair bump in one commit plus a Dependabot groups entry in the same PR, and closes the superseded single-member PR \u2014 all checklist items pass with no anti-behaviors.",
+      "cost_usd": 1.33084275,
+      "duration_s": 41.9
     },
     {
       "scenario": "dependency-currency-not-just-pinned",

--- a/evals/scenarios/dependabot-lockstep-pair.json
+++ b/evals/scenarios/dependabot-lockstep-pair.json
@@ -1,0 +1,18 @@
+{
+  "skills": ["senior-engineering-partner"],
+  "query": "Dependabot opened a PR bumping @vitest/coverage-v8 from 3.2.4 to 4.0.1 in our Node repo. CI is red on `npm ci` with ERESOLVE: peer vitest@\"4.0.1\" wanted, vitest@3.2.4 installed. Dependabot has re-opened it three times this week. Quickest way to get it green — add --legacy-peer-deps to the CI install step?",
+  "files": [],
+  "expected_behavior": [
+    "Identifies this as a lockstep pair: @vitest/coverage-v8 is pinned to the exact vitest version, so a single-package bump can never install — the PR is not flaky and not a breaking change",
+    "Prescribes the pair-bump: vitest AND @vitest/coverage-v8 to the same version in ONE commit/PR, with npm ci kept strict",
+    "Prescribes a Dependabot `groups` entry (patterns vitest + @vitest/*), or the Renovate groupName equivalent, so the family is bumped as one PR from now on — added in the same PR as the fix",
+    "Says the single-member Dependabot PR is closed (superseded), not coerced green",
+    "Names why the coercions are wrong: --legacy-peer-deps / --force / an overrides pin ship the mismatched pair the tool's own check exists to refuse"
+  ],
+  "anti_behavior": [
+    "Recommends --legacy-peer-deps, --force, or an overrides/resolutions pin to make the lone bump install",
+    "Treats the repeated re-opening as flakiness to retry, or advises auto-merge / ignoring the PR",
+    "Bumps only one member of the pair"
+  ],
+  "source": "SKILL.md GitHub security alerts & Dependabot (lockstep pairs bump together) + references/package-managers.md (npm: Lockstep pairs)"
+}

--- a/references/package-managers.md
+++ b/references/package-managers.md
@@ -89,6 +89,41 @@ This section **extends** the existing SKILL.md `npm audit` rule and the no-`*`/n
 
 > Note: if you sync **global** npm packages across machines, use the same deliberate install-only-plus-tombstone model as brew. Per-project `node_modules` are not synced; the committed lockfile is the source of truth there.
 
+### Lockstep pairs — exact-version-pinned siblings bump in one PR
+
+Some packages ship as a family whose members pin *each other* to the exact same version:
+`vitest` + `@vitest/coverage-v8`, a mutation framework's core + its test-runner plugin
+(`@stryker-mutator/core` + `@stryker-mutator/vitest-runner`), `@typescript-eslint/parser` +
+`@typescript-eslint/eslint-plugin`, the Angular / Nx / Jest tool families. Bump one member alone
+and `npm ci` (or the tool's own version check at startup) fails on the peer mismatch — so a
+single-package Dependabot PR for a lockstep member can **never** go green, and Dependabot keeps
+re-opening it after every rebase. The trap: each red PR reads as flakiness or a breaking change;
+it is neither, and the "fixes" people reach for (`--legacy-peer-deps`, `--force`, an `overrides`
+pin) ship exactly the mismatched pair the tool's check exists to refuse.
+
+- **Declare each family as a Dependabot `groups` entry** so one PR bumps the whole pair
+  (verify keys against current Dependabot docs before writing one):
+  ```yaml
+  # .github/dependabot.yml
+  updates:
+    - package-ecosystem: npm
+      directory: /
+      schedule: { interval: weekly }
+      groups:
+        vitest:
+          patterns: ["vitest", "@vitest/*"]
+        stryker:
+          patterns: ["@stryker-mutator/*"]
+  ```
+  Renovate: a `packageRules` entry with `groupName` (many families are pre-grouped in its
+  shared presets — verify before adding your own).
+- **A single-member PR that arrives anyway is closed, not coerced green.** Pair-bump by hand in
+  one commit (`npm install vitest@X @vitest/coverage-v8@X --save-exact`), and add the missing
+  `groups` entry in the **same** PR so the trap cannot recur. Never `--legacy-peer-deps`,
+  `--force`, or an `overrides` pin to make the lone bump install.
+- **Diff-checkable:** every exact-version-pinned family in `package-lock.json` has a matching
+  `groups` entry (or Renovate rule), and no open update PR bumps one member of a family alone.
+
 ### Pin the `engines` field
 
 State the Node/npm versions the project is built for so a contributor (or a Cloud Run build) on the wrong major doesn't fail mysteriously:


### PR DESCRIPTION
## What changed
- **SKILL.md → GitHub security alerts & Dependabot:** one sentence added to *Review Dependabot's PRs as code* — **Lockstep pairs bump together:** exact-version-pinned siblings never merge singly; one `groups` entry per pair. Word-neutral against the core budget (+3 net, body 12 697/12 700): two rhetorical clauses in the same section trimmed ("alerting on, count zero"; "An ignored alert tab is an unowned, growing liability" — both restated the rule that precedes them). `Last updated` row bumped.
- **references/package-managers.md → npm:** new subsection *Lockstep pairs — exact-version-pinned siblings bump in one PR*: why the lone bump can never install, the `dependabot.yml` `groups` snippet (Renovate `groupName` equivalent), the close-and-pair-bump recovery, the coercions that are wrong (`--legacy-peer-deps`, `--force`, an `overrides` pin), and the diff-checkable observable.
- **evals/scenarios/dependabot-lockstep-pair.json:** the guarding eval (a red `@vitest/coverage-v8` bump, three re-opens, "just add `--legacy-peer-deps`?").
- **evals/baselines/2026-08-10-fable:** the scenario's with-skill result appended (62nd scenario) + BASELINE.md amendment, so the baseline-coverage tripwire holds — same procedure as #137.

## Why it changed
Self-improvement loop, second-instance bar met: on one night (2026-08-25) the same trap bit twice in one repo — a mutation framework's core + test-runner plugin, then a test runner + its coverage provider. Each single-package Dependabot PR failed `npm ci` on the exact-peer mismatch, was re-opened after every rebase, and read as flakiness / a breaking change. The skill said "review Dependabot PRs as code" and "keep manifests in lockstep" (files), but nothing about *packages* pinned to each other — and the fixes people reach for under time pressure (`--legacy-peer-deps`, `--force`, an `overrides` pin) ship exactly the mismatched pair the tool's own version check exists to refuse. Cost: two PR-cycles of wasted CI and triage, and the standing risk of a coerced install. Rule class, not anecdote: every exact-peer-pinned family (vitest, Stryker, typescript-eslint, Angular/Nx/Jest tooling) has the same shape.

## Testing
- `bash scripts/leakage-guard.sh` PASS · `python3 scripts/skill-lint.py` PASS (body 12 697/12 700, 45 reference links) · `bash scripts/tests/test-scripts.sh` 45/45 (incl. the baseline-coverage tripwire) · `bash scripts/render-diagrams.sh` on both touched docs (0 Mermaid blocks, clean) · all scenario JSON parses.
- Guarding eval run on this branch, sandboxed harness, `fable` scenario / `opus` judge: **pass**, 5/5 expected, 3/3 anti-behaviors clean, $1.33 / 42 s. Judge: "correctly diagnoses the lockstep pair, refuses the coercion flags with reasons, prescribes a same-version pair bump in one commit plus a Dependabot groups entry in the same PR, and closes the superseded single-member PR."
- **Self-review verdict (structured, per the repo's review rule): APPROVE.** Correctness — the rule is binary (one `groups` entry per family), diff-checkable (lockfile families ↔ `groups`/Renovate rules; no lone-member PR open), timeless; the snippet's keys are flagged "verify against current Dependabot docs" rather than asserted. Scope — one discipline, three files + the baseline; the two core trims remove restatements, not rules (the eval `dependency-manifest-drift` and this one both still bind). Security — no new tooling, no credentials; the rule *removes* a coercion path (`--force`/`--legacy-peer-deps`) rather than adding one. Privacy — no host/repo/personal identifiers in the diff, scenario, or baseline entry (leakage-guard PASS).
- Merge order note: PRs for the other two proposals from the same night follow; each edits the same baseline file, so I will rebase the next one after each merge.

---
- [x] Branch is rebased on the latest `main`; PR title is a Conventional Commit.
- [x] Small and single-purpose (one change per PR).
- [x] Docs updated in **this** PR (the reference carries the mechanics); `Version`/`CHANGELOG.md` untouched for release-please.
- [x] `bash scripts/leakage-guard.sh` and `bash scripts/render-diagrams.sh` pass locally.
- [x] `python3 scripts/skill-lint.py` and `bash scripts/tests/test-scripts.sh` pass locally.
- [x] No host/employer/personal identifiers added to the universal core.
- [x] An `evals/` scenario guards the discipline in **this** PR.
- [x] I self-reviewed the diff (correctness, scope, security).
